### PR TITLE
Widen `hex-literal` to be either `0.4` or `1`

### DIFF
--- a/monero-oxide/Cargo.toml
+++ b/monero-oxide/Cargo.toml
@@ -30,7 +30,7 @@ monero-clsag = { path = "ringct/clsag", version = "0.1", default-features = fals
 monero-borromean = { path = "ringct/borromean", version = "0.1", default-features = false }
 monero-bulletproofs = { path = "ringct/bulletproofs", version = "0.1", default-features = false }
 
-hex-literal = "0.4"
+hex-literal = { version = ">= 0.4, <= 1", default-features = false }
 
 [dev-dependencies]
 hex = { version = "0.4", default-features = false, features = ["std"] }

--- a/monero-oxide/ringct/bulletproofs/Cargo.toml
+++ b/monero-oxide/ringct/bulletproofs/Cargo.toml
@@ -36,7 +36,7 @@ curve25519-dalek = { version = "4", default-features = false, features = ["alloc
 monero-generators = { path = "../../generators", version = "0.4", default-features = false }
 
 [dev-dependencies]
-hex-literal = "0.4"
+hex-literal = { version = ">= 0.4, <= 1", default-features = false }
 
 [features]
 std = [

--- a/monero-oxide/wallet/address/Cargo.toml
+++ b/monero-oxide/wallet/address/Cargo.toml
@@ -30,7 +30,7 @@ monero-primitives = { path = "../../primitives", default-features = false }
 [dev-dependencies]
 rand_core = { version = "0.6", default-features = false, features = ["std"] }
 
-hex-literal = { version = "0.4", default-features = false }
+hex-literal = { version = ">= 0.4, <= 1", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }


### PR DESCRIPTION
Both work without issue with our crates. `1` requires `edition = 2024`, hence why this doesn't simply update to `1`. Per `hex-literal`'s [CHANGELOG](
  https://github.com/RustCrypto/utils/blob/863d4bf540d0152a8f403c4a3e3a720cc2212c58/hex-literal/CHANGELOG.md
), there are no functional differences between `0.4.1` and `1.0.0`.

This leaves the verison present in the `Cargo.lock` as `0.4` due to the current `rust-toolchain.toml` not defining a Rust version which supports the 2024 edition.