### PR TITLE
Update copyright statements

### DIFF
--- a/.github/LICENSE
+++ b/.github/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022-2023 Luke Parker
+Copyright (c) 2022-2025 Luke Parker
+Copyright (c) 2025 monero-oxide Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,7 +1,8 @@
 # MIT License
 #
 # Copyright (c) 2022 just-the-docs
-# Copyright (c) 2022-2024 Luke Parker
+# Copyright (c) 2022-2025 Luke Parker
+# Copyright (c) 2025 monero-oxide Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/monero-oxide/LICENSE
+++ b/monero-oxide/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022-2024 Luke Parker
+Copyright (c) 2022-2025 Luke Parker
+Copyright (c) 2025 monero-oxide Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/monero-oxide/generators/LICENSE
+++ b/monero-oxide/generators/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022-2024 Luke Parker
+Copyright (c) 2022-2025 Luke Parker
+Copyright (c) 2025 monero-oxide Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/monero-oxide/io/LICENSE
+++ b/monero-oxide/io/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022-2024 Luke Parker
+Copyright (c) 2022-2025 Luke Parker
+Copyright (c) 2025 monero-oxide Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/monero-oxide/primitives/LICENSE
+++ b/monero-oxide/primitives/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022-2024 Luke Parker
+Copyright (c) 2022-2025 Luke Parker
+Copyright (c) 2025 monero-oxide Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/monero-oxide/ringct/borromean/LICENSE
+++ b/monero-oxide/ringct/borromean/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022-2024 Luke Parker
+Copyright (c) 2022-2025 Luke Parker
+Copyright (c) 2025 monero-oxide Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/monero-oxide/ringct/bulletproofs/LICENSE
+++ b/monero-oxide/ringct/bulletproofs/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022-2024 Luke Parker
+Copyright (c) 2022-2025 Luke Parker
+Copyright (c) 2025 monero-oxide Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/monero-oxide/ringct/clsag/LICENSE
+++ b/monero-oxide/ringct/clsag/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022-2024 Luke Parker
+Copyright (c) 2022-2025 Luke Parker
+Copyright (c) 2025 monero-oxide Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/monero-oxide/ringct/mlsag/LICENSE
+++ b/monero-oxide/ringct/mlsag/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022-2024 Luke Parker
+Copyright (c) 2022-2025 Luke Parker
+Copyright (c) 2025 monero-oxide Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/monero-oxide/rpc/LICENSE
+++ b/monero-oxide/rpc/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022-2024 Luke Parker
+Copyright (c) 2022-2025 Luke Parker
+Copyright (c) 2025 monero-oxide Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/monero-oxide/rpc/simple-request/LICENSE
+++ b/monero-oxide/rpc/simple-request/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022-2024 Luke Parker
+Copyright (c) 2022-2025 Luke Parker
+Copyright (c) 2025 monero-oxide Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/monero-oxide/verify-chain/LICENSE
+++ b/monero-oxide/verify-chain/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022-2024 Luke Parker
+Copyright (c) 2022-2025 Luke Parker
+Copyright (c) 2025 monero-oxide Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/monero-oxide/wallet/LICENSE
+++ b/monero-oxide/wallet/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022-2024 Luke Parker
+Copyright (c) 2022-2025 Luke Parker
+Copyright (c) 2025 monero-oxide Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/monero-oxide/wallet/address/LICENSE
+++ b/monero-oxide/wallet/address/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022-2024 Luke Parker
+Copyright (c) 2022-2025 Luke Parker
+Copyright (c) 2025 monero-oxide Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Corrects the years this was hosted by Serai. Moves forward with `monero-oxide Developers` (preferences welcome, this was just my first thought).