### PR TITLE
Suggest new MSRV policy

### DIFF
--- a/MSRV Policy.md
+++ b/MSRV Policy.md
@@ -1,7 +1,10 @@
 # MSRV Policy
 
-monero-oxide tracks the latest stable Rust version. monero-oxide _may_ adopt
-a soft-MSRV where [`msrv-shims`](https::/crates.io/crates/msrv-shims) is used
-for all `std` objects introduced after a certain version. This would enable
-downstream consumers to patch `msrv-shims` with the necessary set of polyfills
-to achieve a certain MSRV.
+monero-oxide officially tracks the latest stable Rust version there's merit to
+track. Where possible, `std-shims` (primarily used to provide alternatives to
+members of `std` on `no-std` environments) may provide polyfills so
+monero-oxide may use modern features without actually bumping its MSRV.
+
+Any polyfills provided by `std-shims` are not recommended for usage. They will
+presumably be much more inefficient and will receive a fraction of the testing.
+Only the targeted Rust version is officially supported.


### PR DESCRIPTION
std-shims now offers polyfills as of the latest version, which this policy reflects (rather than talking about a theoretic future).

This doesn't update to the latest `std-shims`, which would allow decreasing quite a few MSRVs. See https://github.com/monero-oxide/monero-oxide/pull/29/commits/051a0659311ecf8865859f06f7a8e63c386d3829.