### PR TITLE
Rename MAX_COMMITMENTS -> MAX_BULLETPROOF_COMMITMENTS

### DIFF
--- a/monero-oxide/generators/src/lib.rs
+++ b/monero-oxide/generators/src/lib.rs
@@ -47,8 +47,8 @@ pub fn H_pow_2() -> &'static [EdwardsPoint; 64] {
   &H_POW_2_CELL
 }
 
-/// The maximum amount of commitments provable for within a single range proof.
-pub const MAX_COMMITMENTS: usize = 16;
+/// The maximum amount of commitments provable for within a single Bulletproof(+).
+pub const MAX_BULLETPROOF_COMMITMENTS: usize = 16;
 /// The amount of bits a value within a commitment may use.
 pub const COMMITMENT_BITS: usize = 64;
 
@@ -67,7 +67,7 @@ pub struct Generators {
 /// once-initialized static.
 pub fn bulletproofs_generators(dst: &'static [u8]) -> Generators {
   // The maximum amount of bits used within a single range proof.
-  const MAX_MN: usize = MAX_COMMITMENTS * COMMITMENT_BITS;
+  const MAX_MN: usize = MAX_BULLETPROOF_COMMITMENTS * COMMITMENT_BITS;
 
   let mut preimage = H.compress().to_bytes().to_vec();
   preimage.extend(dst);

--- a/monero-oxide/ringct/bulletproofs/src/core.rs
+++ b/monero-oxide/ringct/bulletproofs/src/core.rs
@@ -6,7 +6,7 @@ use curve25519_dalek::{
   edwards::EdwardsPoint,
 };
 
-pub(crate) use monero_generators::{MAX_COMMITMENTS, COMMITMENT_BITS};
+pub(crate) use monero_generators::{MAX_BULLETPROOF_COMMITMENTS as MAX_COMMITMENTS, COMMITMENT_BITS};
 
 pub(crate) fn multiexp(pairs: &[(Scalar, EdwardsPoint)]) -> EdwardsPoint {
   let mut buf_scalars = Vec::with_capacity(pairs.len());

--- a/monero-oxide/ringct/bulletproofs/src/lib.rs
+++ b/monero-oxide/ringct/bulletproofs/src/lib.rs
@@ -15,7 +15,7 @@ use zeroize::Zeroizing;
 use curve25519_dalek::edwards::EdwardsPoint;
 
 use monero_io::*;
-pub use monero_generators::MAX_COMMITMENTS;
+pub use monero_generators::MAX_BULLETPROOF_COMMITMENTS as MAX_COMMITMENTS;
 use monero_generators::COMMITMENT_BITS;
 use monero_primitives::Commitment;
 

--- a/monero-oxide/ringct/bulletproofs/src/original/mod.rs
+++ b/monero-oxide/ringct/bulletproofs/src/original/mod.rs
@@ -6,9 +6,13 @@ use zeroize::Zeroize;
 
 use curve25519_dalek::{constants::ED25519_BASEPOINT_POINT, Scalar, EdwardsPoint};
 
-use monero_generators::{H as MONERO_H, Generators, MAX_COMMITMENTS, COMMITMENT_BITS};
+use monero_generators::{H as MONERO_H, Generators, COMMITMENT_BITS};
 use monero_primitives::{Commitment, INV_EIGHT, keccak256_to_scalar};
-use crate::{core::multiexp, scalar_vector::ScalarVector, BulletproofsBatchVerifier};
+use crate::{
+  core::{MAX_COMMITMENTS, multiexp},
+  scalar_vector::ScalarVector,
+  BulletproofsBatchVerifier,
+};
 
 pub(crate) mod inner_product;
 use inner_product::*;

--- a/monero-oxide/wallet/src/send/mod.rs
+++ b/monero-oxide/wallet/src/send/mod.rs
@@ -16,7 +16,7 @@ use frost::FrostError;
 
 use crate::{
   io::*,
-  generators::{MAX_COMMITMENTS, hash_to_point},
+  generators::{MAX_BULLETPROOF_COMMITMENTS, hash_to_point},
   ringct::{
     clsag::{ClsagError, ClsagContext, Clsag},
     RctType, RctPrunable, RctProofs,
@@ -282,7 +282,7 @@ impl SignableTransaction {
       }
     }
 
-    if self.payments.len() > MAX_COMMITMENTS {
+    if self.payments.len() > MAX_BULLETPROOF_COMMITMENTS {
       Err(SendError::TooManyOutputs)?;
     }
 


### PR DESCRIPTION
monero-bulletproofs re-exports it as MAX_COMMITMENTS (as it itself is the appropriate scoping for it).

Fixes #30.