### PR TITLE
Document, clarify, and optimize hash-to-point

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "bitflags"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +203,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -242,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "dalek-ff-group"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e96a0481cd1b5be574a2638585309753aca918378fc87afaa90bcc6a9df849b"
+checksum = "0f9d720a1cc9388e4bcee44959d0471ec1d578e49b7fffc82d2e5b9a4a5b74cc"
 dependencies = [
  "crypto-bigint",
  "curve25519-dalek",
@@ -759,6 +766,7 @@ dependencies = [
 name = "monero-generators"
 version = "0.4.0"
 dependencies = [
+ "crypto-bigint",
  "curve25519-dalek",
  "dalek-ff-group",
  "group",
@@ -1206,6 +1214,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
  "serde",
 ]
 

--- a/monero-oxide/generators/Cargo.toml
+++ b/monero-oxide/generators/Cargo.toml
@@ -21,9 +21,10 @@ std-shims = { version = "^0.1.2", default-features = false }
 subtle = { version = "^2.4", default-features = false }
 
 sha3 = { version = "0.10", default-features = false }
-curve25519-dalek = { version = "4", default-features = false, features = ["alloc", "zeroize"] }
 
-group = { version = "0.13", default-features = false }
+group = { version = "0.13", default-features = false, features = ["alloc"] }
+curve25519-dalek = { version = "4", default-features = false, features = ["alloc", "zeroize"] }
+crypto-bigint = { version = "0.5", default-features = false, features = ["alloc"] }
 dalek-ff-group = { version = "0.4", default-features = false }
 
 monero-io = { path = "../io", version = "0.1", default-features = false }
@@ -39,7 +40,7 @@ std = [
 
   "sha3/std",
 
-  "group/alloc",
+  "dalek-ff-group/std",
 
   "monero-io/std"
 ]

--- a/monero-oxide/generators/src/hash_to_point.rs
+++ b/monero-oxide/generators/src/hash_to_point.rs
@@ -1,4 +1,4 @@
-use subtle::ConditionallySelectable;
+use subtle::{ConstantTimeEq, ConditionallySelectable};
 
 use curve25519_dalek::edwards::EdwardsPoint;
 
@@ -10,37 +10,70 @@ use monero_io::decompress_point;
 use crate::keccak256;
 
 /// Monero's `hash_to_ec` function.
+///
+/// This achieves parity with https://github.com/monero-project/monero
+///   /blob/389e3ba1df4a6df4c8f9d116aa239d4c00f5bc78/src/crypto/crypto.cpp#L611, inlining the
+/// `ge_fromfe_frombytes_vartime` function (https://github.com/monero-project/monero
+///   /blob/389e3ba1df4a6df4c8f9d116aa239d4c00f5bc78/src/crypto/crypto-ops.c#L2309). This
+/// implementation runs in constant time.
+///
+/// According to the original authors, this would implement https://arxiv.org/abs/0706.1448, yet
+/// the referenced methodology doesn't appear present. Notes by Shen Noether also describe the
+/// algorithm (https://web.getmonero.org/resources/research-lab/pubs/ge_fromfe.pdf), yet without
+/// reviewing its security and in a very straight-forward fashion. This function does attempt to
+/// be well documented to explain the algorithm however.
 pub fn hash_to_point(bytes: [u8; 32]) -> EdwardsPoint {
+  // Curve25519 is a Montgomery curve with equation y^2 = x^3 + 486662 x^2 + x
   #[allow(non_snake_case)]
   let A = FieldElement::from(486662u64);
 
   let v = FieldElement::from_square(keccak256(&bytes)).double();
   let w = v + FieldElement::ONE;
-  let x = w.square() + (-A.square() * v);
 
-  // This isn't the complete X, yet its initial value
-  // We don't calculate the full X, and instead solely calculate Y, letting dalek reconstruct X
-  // While inefficient, it solves API boundaries and reduces the amount of work done here
-  #[allow(non_snake_case)]
-  let X = {
+  let w_over_x_was_square = {
     let u = w;
-    let v = x;
-    let v3 = v * v * v;
-    let uv3 = u * v3;
-    let v7 = v3 * v3 * v;
-    let uv7 = u * v7;
-    uv3 *
-      uv7.pow(
-        (-FieldElement::from(5u8)) *
-          FieldElement::from(8u8).invert().expect("eight was coprime with the prime 2^{255}-19"),
-      )
-  };
-  let x = X.square() * x;
+    let v = w.square() + (-A.square() * v);
 
-  let y = w - x;
-  let non_zero_0 = !y.is_zero();
-  let y_if_non_zero_0 = w + x;
-  let sign = non_zero_0 & (!y_if_non_zero_0.is_zero());
+    // Parts of sqrt_ratio_i, as documented here: https://ristretto.group/formulas/invsqrt.html
+    {
+      // Step 1
+      #[allow(non_snake_case)]
+      let r = {
+        let v3 = v * v * v;
+        let uv3 = u * v3;
+        let v7 = v3 * v3 * v;
+        let uv7 = u * v7;
+        uv3 *
+          uv7.pow(
+            (-FieldElement::from(5u8)) *
+              FieldElement::from(8u8)
+                .invert()
+                .expect("eight was coprime with the prime 2^{255}-19"),
+          )
+      };
+      // Step 2
+      let c = r.square() * v;
+
+      // Step 3
+      let correct_sign_sqrt = c.ct_eq(&u);
+      // Step 4
+      let flipped_sign_sqrt = c.ct_eq(&-u);
+
+      // Skips steps 5-7, not updating (nor returning) `r`
+
+      correct_sign_sqrt | flipped_sign_sqrt
+    }
+  };
+
+  /*
+    The following code does not calculate the full coordinates of the resulting point, solely the
+    `Y` coordinate and the sign of the `X` coordinate. We then encode this, passing it to
+    curve25519-dalek to decompress and yield us the instantiated point.
+
+    This resolves the API boundary of how we cannot instantiate a `curve25519_dalek::EdwardsPoint`
+    from its coordinates.
+  */
+  let sign = !w_over_x_was_square;
 
   let mut z = -A;
   z *= FieldElement::conditional_select(&v, &FieldElement::from(1u8), sign);

--- a/monero-oxide/generators/src/hash_to_point.rs
+++ b/monero-oxide/generators/src/hash_to_point.rs
@@ -28,13 +28,14 @@ pub fn hash_to_point(bytes: [u8; 32]) -> EdwardsPoint {
     Curve25519 is a Montgomery curve with equation v^2 = u^3 + 486662 u^2 + u.
 
     A Curve25519 point `(u, v)` may be mapped to an Ed25519 point `(x, y)` with the map
-    `(sqrt(-(A+2)) u/v, (u-1) / (v+1))`.
+    `(sqrt(-(A + 2)) u / v, (u - 1) / (u + 1))`.
   */
   #[allow(non_snake_case)]
   let A = FieldElement::from(486662u64);
   #[allow(non_snake_case)]
   let negative_A = -A;
 
+  // OPEN QUESTION: What is this `step_1` value?
   let step_1 = {
     use crypto_bigint::{Encoding, U256};
     FieldElement::from_u256(&U256::from_le_bytes(keccak256(&bytes)))
@@ -42,13 +43,28 @@ pub fn hash_to_point(bytes: [u8; 32]) -> EdwardsPoint {
   let step_1 = step_1.square();
   let step_1 = step_1.double();
 
-  let step_2 = step_1 + FieldElement::ONE;
+  /*
+    `z` is used as the denominator within projective coordinates for a point on Curve25519. We know
+    it's non-zero as:
 
-  // derivative_was_square = (step_2 / (step_2^2 - (A^2 * step_1))).is_square()
-  let derivative_was_square = {
-    // The inputs to the following inlined function, in its preferred notation
-    let u = step_2;
-    let v = step_2.square() - (A.square() * step_1);
+    ```sage
+    p = 2**255 - 19
+    Mod((p - 1) * inverse_mod(2, p), p).is_square() == False
+    ```
+  */
+  let z = step_1 + FieldElement::ONE;
+
+  // u_over_v = z / (z^2 - (A^2 * step_1))
+  // u_over_v_was_square = u_over_v.is_square()
+  let u_over_v_was_square = {
+    /*
+      The following inlined function defines its arguments as `u, v`, which conflicts with how
+      Curve25519 points are considered `(u, v)`. These are NOT coordinates for a point on
+      Curve25519.
+    */
+    // OPEN QUESTION: Why are these the values used here?
+    let u = z;
+    let v = z.square() - (A.square() * step_1);
 
     /*
       sqrt_ratio_i(u, v) primarily calculates the square root of `u / v`, at roughly half the cost
@@ -59,7 +75,7 @@ pub fn hash_to_point(bytes: [u8; 32]) -> EdwardsPoint {
       The following implements parts of ristretto.group's detailing of the algorithm, in its
       notation.
     */
-    let derivative_was_square = {
+    let u_over_v_was_square = {
       // Step 1
       #[allow(non_snake_case)]
       let r = {
@@ -89,11 +105,12 @@ pub fn hash_to_point(bytes: [u8; 32]) -> EdwardsPoint {
     };
 
     debug_assert_eq!(
-      bool::from(derivative_was_square),
-      Option::<FieldElement>::from((u * v.invert().unwrap()).sqrt()).is_some()
+      bool::from(u_over_v_was_square),
+      Option::<FieldElement>::from((u * v.invert().unwrap()).sqrt()).is_some(),
+      "sqrt_ratio_i implementation returned an incorrect result"
     );
 
-    derivative_was_square
+    u_over_v_was_square
   };
 
   /*
@@ -105,37 +122,40 @@ pub fn hash_to_point(bytes: [u8; 32]) -> EdwardsPoint {
     from its coordinates.
   */
 
-  let step_3 =
-    FieldElement::conditional_select(&(negative_A * step_1), &negative_A, !derivative_was_square);
+  /*
+    This is the _Projective_ `u` coordinate for a point on Curve25519. The Affine `u` coordinate
+    would be `u / z`.
+  */
+  // OPEN QUESTION: Why is this a coordinate of a point on Curve25519? Is it uniform?
+  let u =
+    FieldElement::conditional_select(&(negative_A * step_1), &negative_A, !u_over_v_was_square);
 
   /*
-    sign = !derivative_was_square
+    Map from the Curve25519 `u` coordinate to an Ed25519 `y` coordinate.
 
-    If sign, `step_3 = -486662`, else, `step_3 = -486662 * step_1`
-    `step_2 = step_1 + 1`
+    Instead of normalizing, then mapping, the following equation optimizes to a single inversion.
 
-    We need `step_3 + step_2 \ne 0`, which would require `step_3 \cong -step_2 \mod 2^{255}-19`.
-    This requires:
-    - If `sign`, `step_1 \mod 2^{255}-19 \ne 486661`.
-    - If `!sign`, `(step_1 + 1) \mod 2^{255}-19 \ne (step_1 * 486662) \mod 2^{255}-19` which is
-      equivalent to `(step_1 * 486661) \mod 2^{255}-19 \ne 1`.
-
-    In summary, if `sign`, `step_1` must not equal `486661`, and if `!sign`, `step_1` must not be
-    the multiplicative inverse of `486661`. Since `step_1` is the output of a hash function, this
-    should have negligible probability. Additionally, since the definition of `sign` is dependent
-    on `step_1`, it may be truly impossible to reach.
+    If `u / z` is actually the coordinate of a point on Curve25519, the following `unwrap` calls
+    will never trigger due to the map from Curve25519 to Ed25519 being well-defined.
   */
-  #[allow(non_snake_case)]
-  let Y = (step_3 - step_2) *
-    (step_3 + step_2).invert().expect(&format!(
-      "step_1 ({:?}) was 486661 or 486661^{{-1}} depending on was_square ({}). input: {:?}",
-      step_1,
-      bool::from(derivative_was_square),
-      bytes
-    ));
+  let y = (u - z) * (u + z).invert().unwrap();
+  debug_assert_eq!(
+    y,
+    {
+      let u = u * z.invert().expect("unreachable modulo 2^{255} - 19");
+      (u - FieldElement::ONE) * (u + FieldElement::ONE).invert().unwrap()
+    },
+    "normalize and map wasn't equivalent to normalize, then map"
+  );
 
-  let mut bytes = Y.to_repr();
-  bytes[31] |= (!derivative_was_square).unwrap_u8() << 7;
+  // Encode the `y` coordinate for us to then pass to curve25519_dalek
+  let mut bytes = y.to_repr();
+  // Add the sign bit for which `x` coordinate to take.
+  /*
+    OPEN QUESTION: How does whether this value was square translate to which `x` coordinate to
+    take?
+  */
+  bytes[31] |= (!u_over_v_was_square).unwrap_u8() << 7;
 
   /*
     Ed25519 point decompression works as follows.
@@ -151,7 +171,9 @@ pub fn hash_to_point(bytes: [u8; 32]) -> EdwardsPoint {
     d = (-121665) * inverse_mod(121666, p)
     Mod((p - 1) * inverse_mod(d, p), p).is_square() == False
     ```
-  */
 
+    If `u / z` is actually the coordinate of a point on Curve25519, `y` will actually be the
+    coordinate of a point on Ed25519 due to the map from Curve25519 to Ed25519 being well-defined.
+  */
   decompress_point(bytes).expect("point from hash-to-curve wasn't on-curve").mul_by_cofactor()
 }

--- a/monero-oxide/generators/src/hash_to_point.rs
+++ b/monero-oxide/generators/src/hash_to_point.rs
@@ -1,8 +1,7 @@
 use subtle::{ConstantTimeEq, ConditionallySelectable};
 
-use curve25519_dalek::edwards::EdwardsPoint;
-
 use group::ff::{Field, PrimeField};
+use curve25519_dalek::edwards::EdwardsPoint;
 use dalek_ff_group::FieldElement;
 
 use monero_io::decompress_point;
@@ -17,25 +16,50 @@ use crate::keccak256;
 ///   /blob/389e3ba1df4a6df4c8f9d116aa239d4c00f5bc78/src/crypto/crypto-ops.c#L2309). This
 /// implementation runs in constant time.
 ///
-/// According to the original authors, this would implement https://arxiv.org/abs/0706.1448, yet
-/// the referenced methodology doesn't appear present. Notes by Shen Noether also describe the
-/// algorithm (https://web.getmonero.org/resources/research-lab/pubs/ge_fromfe.pdf), yet without
-/// reviewing its security and in a very straight-forward fashion. This function does attempt to
-/// be well documented to explain the algorithm however.
+/// According to the original authors
+/// (https://web.archive.org/web/20201028121818/https://cryptonote.org/whitepaper.pdf), this would
+/// implement https://arxiv.org/abs/0706.1448, yet the cited methodology doesn't appear present.
+/// Notes by Shen Noether also describe the algorithm
+/// (https://web.getmonero.org/resources/research-lab/pubs/ge_fromfe.pdf), yet without reviewing
+/// its security and in a very straight-forward fashion. This function does attempt to be well
+/// documented to explain the algorithm however.
 pub fn hash_to_point(bytes: [u8; 32]) -> EdwardsPoint {
-  // Curve25519 is a Montgomery curve with equation y^2 = x^3 + 486662 x^2 + x
+  /*
+    Curve25519 is a Montgomery curve with equation v^2 = u^3 + 486662 u^2 + u.
+
+    A Curve25519 point `(u, v)` may be mapped to an Ed25519 point `(x, y)` with the map
+    `(sqrt(-(A+2)) u/v, (u-1) / (v+1))`.
+  */
   #[allow(non_snake_case)]
   let A = FieldElement::from(486662u64);
+  #[allow(non_snake_case)]
+  let negative_A = -A;
 
-  let v = FieldElement::from_square(keccak256(&bytes)).double();
-  let w = v + FieldElement::ONE;
+  let step_1 = {
+    use crypto_bigint::{Encoding, U256};
+    FieldElement::from_u256(&U256::from_le_bytes(keccak256(&bytes)))
+  };
+  let step_1 = step_1.square();
+  let step_1 = step_1.double();
 
-  let w_over_x_was_square = {
-    let u = w;
-    let v = w.square() + (-A.square() * v);
+  let step_2 = step_1 + FieldElement::ONE;
 
-    // Parts of sqrt_ratio_i, as documented here: https://ristretto.group/formulas/invsqrt.html
-    {
+  // derivative_was_square = (step_2 / (step_2^2 - (A^2 * step_1))).is_square()
+  let derivative_was_square = {
+    // The inputs to the following inlined function, in its preferred notation
+    let u = step_2;
+    let v = step_2.square() - (A.square() * step_1);
+
+    /*
+      sqrt_ratio_i(u, v) primarily calculates the square root of `u / v`, at roughly half the cost
+      of calculating `sqrt(u * v.invert())`. Documentation be found at the following links:
+      - https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.3
+      - https://ristretto.group/formulas/invsqrt.html
+
+      The following implements parts of ristretto.group's detailing of the algorithm, in its
+      notation.
+    */
+    let derivative_was_square = {
       // Step 1
       #[allow(non_snake_case)]
       let r = {
@@ -62,7 +86,14 @@ pub fn hash_to_point(bytes: [u8; 32]) -> EdwardsPoint {
       // Skips steps 5-7, not updating (nor returning) `r`
 
       correct_sign_sqrt | flipped_sign_sqrt
-    }
+    };
+
+    debug_assert_eq!(
+      bool::from(derivative_was_square),
+      Option::<FieldElement>::from((u * v.invert().unwrap()).sqrt()).is_some()
+    );
+
+    derivative_was_square
   };
 
   /*
@@ -73,32 +104,54 @@ pub fn hash_to_point(bytes: [u8; 32]) -> EdwardsPoint {
     This resolves the API boundary of how we cannot instantiate a `curve25519_dalek::EdwardsPoint`
     from its coordinates.
   */
-  let sign = !w_over_x_was_square;
 
-  let mut z = -A;
-  z *= FieldElement::conditional_select(&v, &FieldElement::from(1u8), sign);
-  #[allow(non_snake_case)]
-  let Z = z + w;
-  #[allow(non_snake_case)]
-  let mut Y = z - w;
+  let step_3 =
+    FieldElement::conditional_select(&(negative_A * step_1), &negative_A, !derivative_was_square);
 
   /*
-    If sign, `z = -486662`, else, `z = -486662 * v`
-    `w = v + 1`
+    sign = !derivative_was_square
 
-    We need `z + w \ne 0`, which would require `z \cong -w \mod 2^{255}-19`. This requires:
-    - If `sign`, `v \mod 2^{255}-19 \ne 486661`.
-    - If `!sign`, `(v + 1) \mod 2^{255}-19 \ne (v * 486662) \mod 2^{255}-19` which is equivalent to
-      `(v * 486661) \mod 2^{255}-19 \ne 1`.
+    If sign, `step_3 = -486662`, else, `step_3 = -486662 * step_1`
+    `step_2 = step_1 + 1`
 
-    In summary, if `sign`, `v` must not `486661`, and if `!sign`, `v` must not be the
-    multiplicative inverse of `486661`. Since `v` is the output of a hash function, this should
-    have negligible probability. Additionally, since the definition of `sign` is dependent on `v`,
-    it may be truly impossible to reach.
+    We need `step_3 + step_2 \ne 0`, which would require `step_3 \cong -step_2 \mod 2^{255}-19`.
+    This requires:
+    - If `sign`, `step_1 \mod 2^{255}-19 \ne 486661`.
+    - If `!sign`, `(step_1 + 1) \mod 2^{255}-19 \ne (step_1 * 486662) \mod 2^{255}-19` which is
+      equivalent to `(step_1 * 486661) \mod 2^{255}-19 \ne 1`.
+
+    In summary, if `sign`, `step_1` must not equal `486661`, and if `!sign`, `step_1` must not be
+    the multiplicative inverse of `486661`. Since `step_1` is the output of a hash function, this
+    should have negligible probability. Additionally, since the definition of `sign` is dependent
+    on `step_1`, it may be truly impossible to reach.
   */
-  Y *= Z.invert().expect("if sign, v was 486661. if !sign, v was 486661^{-1}");
+  #[allow(non_snake_case)]
+  let Y = (step_3 - step_2) *
+    (step_3 + step_2).invert().expect(&format!(
+      "step_1 ({:?}) was 486661 or 486661^{{-1}} depending on was_square ({}). input: {:?}",
+      step_1,
+      bool::from(derivative_was_square),
+      bytes
+    ));
+
   let mut bytes = Y.to_repr();
-  bytes[31] |= sign.unwrap_u8() << 7;
+  bytes[31] |= (!derivative_was_square).unwrap_u8() << 7;
+
+  /*
+    Ed25519 point decompression works as follows.
+
+    d = (-121665) / 121666
+    x^2 = (y^2 - 1) / ((d y^2) + 1)
+
+    Note `(d y^2) + 1` will always be non-zero as `((2^{255} - 19) - 1) / d` doesn't have a square
+    root modulo `2^{255} - 19`.
+
+    ```sage
+    p = 2**255 - 19
+    d = (-121665) * inverse_mod(121666, p)
+    Mod((p - 1) * inverse_mod(d, p), p).is_square() == False
+    ```
+  */
 
   decompress_point(bytes).expect("point from hash-to-curve wasn't on-curve").mul_by_cofactor()
 }


### PR DESCRIPTION
Years ago, I ported Monero's `hash_to_ec` function to Rust (as seen within the current monero-oxide). Monero using a hash-to-point with unclear origin, a lack of proven security, and little writing, is very annoying. While theoretically it could break the entire project, practically it's a few bits of bias (practically irrelevant) and just incredibly annoying. The upcoming FCMP++ hard fork would be a good opportunity to replace it though, if the hash-to-point algorithm is poor.

This PR adds documentation on prior literature and attempts to 'reverse engineer' what the algorithm is doing. The work I've already done should make it much more readable, stating the remaining open questions. Additionally, when `debug_assertions` is off, it should be somewhat more efficient due to removing unnecessary operations. When `debug_assertions` is on, I believe it'd be ~3x slower (due to additionally running a ~2x as slow algorithm to sanity check the fast algorithm).

This is a draft as I'm still trying to answer the remaining questions I opened. There's no reason to merge every bit of documentation, as I document it, but this probably shouldn't be buried in a branch I have due to the larger impact to the Monero project...