### PR TITLE
Remove potentially-ambiguous usages of `AsRef::as_ref`

### DIFF
--- a/monero-oxide/primitives/src/lib.rs
+++ b/monero-oxide/primitives/src/lib.rs
@@ -70,7 +70,7 @@ pub fn keccak256(data: impl AsRef<[u8]>) -> [u8; 32] {
 ///
 /// This function panics if it finds the Keccak-256 preimage for [0; 32].
 pub fn keccak256_to_scalar(data: impl AsRef<[u8]>) -> Scalar {
-  let scalar = Scalar::from_bytes_mod_order(keccak256(data.as_ref()));
+  let scalar = Scalar::from_bytes_mod_order(keccak256(&data));
   // Monero will explicitly error in this case
   // This library acknowledges its practical impossibility of it occurring, and doesn't bother to
   // code in logic to handle it. That said, if it ever occurs, something must happen in order to

--- a/monero-oxide/ringct/bulletproofs/src/plus/aggregate_range_proof.rs
+++ b/monero-oxide/ringct/bulletproofs/src/plus/aggregate_range_proof.rs
@@ -65,10 +65,8 @@ impl<'a> AggregateRangeStatement<'a> {
   }
 
   fn transcript_A(transcript: &mut Scalar, A: EdwardsPoint) -> (Scalar, Scalar) {
-    let y = keccak256_to_scalar(
-      [transcript.to_bytes().as_ref(), A.compress().to_bytes().as_ref()].concat(),
-    );
-    let z = keccak256_to_scalar(y.to_bytes().as_ref());
+    let y = keccak256_to_scalar([transcript.to_bytes(), A.compress().to_bytes()].concat());
+    let z = keccak256_to_scalar(y.to_bytes());
     *transcript = z;
     (y, z)
   }

--- a/monero-oxide/ringct/bulletproofs/src/plus/transcript.rs
+++ b/monero-oxide/ringct/bulletproofs/src/plus/transcript.rs
@@ -14,5 +14,5 @@ pub(crate) static TRANSCRIPT: LazyLock<[u8; 32]> = LazyLock::new(|| {
 pub(crate) fn initial_transcript(commitments: core::slice::Iter<'_, EdwardsPoint>) -> Scalar {
   let commitments_hash =
     keccak256_to_scalar(commitments.flat_map(|V| V.compress().to_bytes()).collect::<Vec<_>>());
-  keccak256_to_scalar([TRANSCRIPT.as_ref(), &commitments_hash.to_bytes()].concat())
+  keccak256_to_scalar([*TRANSCRIPT, commitments_hash.to_bytes()].concat())
 }

--- a/monero-oxide/ringct/bulletproofs/src/plus/weighted_inner_product.rs
+++ b/monero-oxide/ringct/bulletproofs/src/plus/weighted_inner_product.rs
@@ -80,12 +80,7 @@ impl WipStatement {
 
   fn transcript_L_R(transcript: &mut Scalar, L: EdwardsPoint, R: EdwardsPoint) -> Scalar {
     let e = keccak256_to_scalar(
-      [
-        transcript.to_bytes().as_ref(),
-        L.compress().to_bytes().as_ref(),
-        R.compress().to_bytes().as_ref(),
-      ]
-      .concat(),
+      [transcript.to_bytes(), L.compress().to_bytes(), R.compress().to_bytes()].concat(),
     );
     *transcript = e;
     e
@@ -93,12 +88,7 @@ impl WipStatement {
 
   fn transcript_A_B(transcript: &mut Scalar, A: EdwardsPoint, B: EdwardsPoint) -> Scalar {
     let e = keccak256_to_scalar(
-      [
-        transcript.to_bytes().as_ref(),
-        A.compress().to_bytes().as_ref(),
-        B.compress().to_bytes().as_ref(),
-      ]
-      .concat(),
+      [transcript.to_bytes(), A.compress().to_bytes(), B.compress().to_bytes()].concat(),
     );
     *transcript = e;
     e

--- a/monero-oxide/ringct/clsag/src/multisig.rs
+++ b/monero-oxide/ringct/clsag/src/multisig.rs
@@ -98,7 +98,7 @@ impl ClsagAddendum {
 
 impl WriteAddendum for ClsagAddendum {
   fn write<W: Write>(&self, writer: &mut W) -> io::Result<()> {
-    writer.write_all(self.key_image_share.compress().to_bytes().as_ref())
+    writer.write_all(&self.key_image_share.compress().to_bytes())
   }
 }
 

--- a/monero-oxide/rpc/src/lib.rs
+++ b/monero-oxide/rpc/src/lib.rs
@@ -558,7 +558,7 @@ pub trait Rpc: Sync + Clone {
       let res: BlockResponse =
         self.json_rpc_call("get_block", Some(json!({ "hash": hex::encode(hash) }))).await?;
 
-      let block = Block::read::<&[u8]>(&mut rpc_hex(&res.blob)?.as_ref())
+      let block = Block::read(&mut rpc_hex(&res.blob)?.as_slice())
         .map_err(|_| RpcError::InvalidNode("invalid block".to_string()))?;
       if block.hash() != hash {
         Err(RpcError::InvalidNode("different block than requested (hash)".to_string()))?;
@@ -584,7 +584,7 @@ pub trait Rpc: Sync + Clone {
       let res: BlockResponse =
         self.json_rpc_call("get_block", Some(json!({ "height": number }))).await?;
 
-      let block = Block::read::<&[u8]>(&mut rpc_hex(&res.blob)?.as_ref())
+      let block = Block::read(&mut rpc_hex(&res.blob)?.as_slice())
         .map_err(|_| RpcError::InvalidNode("invalid block".to_string()))?;
 
       // Make sure this is actually the block for this number
@@ -873,7 +873,7 @@ pub trait Rpc: Sync + Clone {
       request.extend(hash);
 
       let indexes_buf = self.bin_call("get_o_indexes.bin", request).await?;
-      let mut indexes: &[u8] = indexes_buf.as_ref();
+      let mut indexes = indexes_buf.as_slice();
 
       (|| {
         let mut res = None;

--- a/monero-oxide/src/merkle.rs
+++ b/monero-oxide/src/merkle.rs
@@ -33,7 +33,7 @@ pub fn merkle_root(mut leafs: Vec<[u8; 32]>) -> Option<[u8; 32]> {
         let mut paired_hashes = Vec::with_capacity(overage);
         while let Some(left) = rightmost.next() {
           let right = rightmost.next().expect("rightmost is of even length");
-          paired_hashes.push(keccak256([left.as_ref(), &right].concat()));
+          paired_hashes.push(keccak256([left, right].concat()));
         }
         drop(rightmost);
 

--- a/monero-oxide/wallet/src/extra.rs
+++ b/monero-oxide/wallet/src/extra.rs
@@ -229,7 +229,7 @@ impl Extra {
   pub fn payment_id(&self) -> Option<PaymentId> {
     for field in &self.0 {
       if let ExtraField::Nonce(data) = field {
-        return PaymentId::read::<&[u8]>(&mut data.as_ref()).ok();
+        return PaymentId::read(&mut data.as_slice()).ok();
       }
     }
     None

--- a/monero-oxide/wallet/src/lib.rs
+++ b/monero-oxide/wallet/src/lib.rs
@@ -87,11 +87,11 @@ impl SharedKeyDerivations {
         .expect("write failed but <Vec as io::Write> doesn't fail");
     }
 
-    let view_tag = keccak256([b"view_tag".as_ref(), &output_derivation].concat())[0];
+    let view_tag = keccak256([b"view_tag".as_slice(), &output_derivation].concat())[0];
 
     // uniqueness ||
     let output_derivation = if let Some(uniqueness) = uniqueness {
-      Zeroizing::new([uniqueness.as_ref(), &output_derivation].concat())
+      Zeroizing::new([uniqueness.as_slice(), &output_derivation].concat())
     } else {
       output_derivation
     };
@@ -112,7 +112,7 @@ impl SharedKeyDerivations {
 
     let mut payment_id_xor = [0; 8];
     payment_id_xor
-      .copy_from_slice(&keccak256([output_derivation.as_ref(), [0x8d].as_ref()].concat())[.. 8]);
+      .copy_from_slice(&keccak256([output_derivation.as_slice(), &[0x8d]].concat())[.. 8]);
     payment_id_xor
   }
 

--- a/monero-oxide/wallet/src/scan.rs
+++ b/monero-oxide/wallet/src/scan.rs
@@ -128,7 +128,7 @@ impl InternalScanner {
     }
 
     // Read the extra field
-    let Ok(extra) = Extra::read::<&[u8]>(&mut tx.prefix().extra.as_ref()) else {
+    let Ok(extra) = Extra::read(&mut tx.prefix().extra.as_slice()) else {
       return Ok(Timelocked(vec![]));
     };
 

--- a/monero-oxide/wallet/src/tests/extra.rs
+++ b/monero-oxide/wallet/src/tests/extra.rs
@@ -74,7 +74,7 @@ fn test_write_buf(extra: &Extra, buf: &[u8]) {
 #[test]
 fn empty_extra() {
   let buf: Vec<u8> = vec![];
-  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  let extra = Extra::read(&mut buf.as_slice()).unwrap();
   assert!(extra.0.is_empty());
   test_write_buf(&extra, &buf);
 }
@@ -82,7 +82,7 @@ fn empty_extra() {
 #[test]
 fn padding_only_size_1() {
   let buf: Vec<u8> = vec![0];
-  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  let extra = Extra::read(&mut buf.as_slice()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::Padding(1)]);
   test_write_buf(&extra, &buf);
 }
@@ -90,7 +90,7 @@ fn padding_only_size_1() {
 #[test]
 fn padding_only_size_2() {
   let buf: Vec<u8> = vec![0, 0];
-  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  let extra = Extra::read(&mut buf.as_slice()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::Padding(2)]);
   test_write_buf(&extra, &buf);
 }
@@ -98,7 +98,7 @@ fn padding_only_size_2() {
 #[test]
 fn padding_only_max_size() {
   let buf: Vec<u8> = vec![0; MAX_TX_EXTRA_PADDING_COUNT];
-  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  let extra = Extra::read(&mut buf.as_slice()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::Padding(MAX_TX_EXTRA_PADDING_COUNT)]);
   test_write_buf(&extra, &buf);
 }
@@ -106,21 +106,21 @@ fn padding_only_max_size() {
 #[test]
 fn padding_only_exceed_max_size() {
   let buf: Vec<u8> = vec![0; MAX_TX_EXTRA_PADDING_COUNT + 1];
-  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  let extra = Extra::read(&mut buf.as_slice()).unwrap();
   assert!(extra.0.is_empty());
 }
 
 #[test]
 fn invalid_padding_only() {
   let buf: Vec<u8> = vec![0, 42];
-  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  let extra = Extra::read(&mut buf.as_slice()).unwrap();
   assert!(extra.0.is_empty());
 }
 
 #[test]
 fn pub_key_only() {
   let buf: Vec<u8> = PUB_KEY_BYTES.to_vec();
-  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  let extra = Extra::read(&mut buf.as_slice()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::PublicKey(pub_key())]);
   test_write_buf(&extra, &buf);
 }
@@ -128,7 +128,7 @@ fn pub_key_only() {
 #[test]
 fn extra_nonce_only() {
   let buf: Vec<u8> = vec![2, 1, 42];
-  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  let extra = Extra::read(&mut buf.as_slice()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::Nonce(vec![42])]);
   test_write_buf(&extra, &buf);
 }
@@ -138,7 +138,7 @@ fn extra_nonce_only_wrong_size() {
   let mut buf: Vec<u8> = vec![0; 20];
   buf[0] = 2;
   buf[1] = 255;
-  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  let extra = Extra::read(&mut buf.as_slice()).unwrap();
   assert!(extra.0.is_empty());
 }
 
@@ -150,7 +150,7 @@ fn pub_key_and_padding() {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   ]);
-  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  let extra = Extra::read(&mut buf.as_slice()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::PublicKey(pub_key()), ExtraField::Padding(76)]);
   test_write_buf(&extra, &buf);
 }
@@ -159,14 +159,14 @@ fn pub_key_and_padding() {
 fn pub_key_and_invalid_padding() {
   let mut buf: Vec<u8> = PUB_KEY_BYTES.to_vec();
   buf.extend([0, 1]);
-  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  let extra = Extra::read(&mut buf.as_slice()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::PublicKey(pub_key())]);
 }
 
 #[test]
 fn extra_mysterious_minergate_only() {
   let buf: Vec<u8> = vec![222, 1, 42];
-  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  let extra = Extra::read(&mut buf.as_slice()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::MysteriousMinergate(vec![42])]);
   test_write_buf(&extra, &buf);
 }
@@ -176,7 +176,7 @@ fn extra_mysterious_minergate_only_large() {
   let mut buf: Vec<u8> = vec![222];
   write_varint(&512u64, &mut buf).unwrap();
   buf.extend_from_slice(&vec![0; 512]);
-  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  let extra = Extra::read(&mut buf.as_slice()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::MysteriousMinergate(vec![0; 512])]);
   test_write_buf(&extra, &buf);
 }
@@ -186,7 +186,7 @@ fn extra_mysterious_minergate_only_wrong_size() {
   let mut buf: Vec<u8> = vec![0; 20];
   buf[0] = 222;
   buf[1] = 255;
-  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  let extra = Extra::read(&mut buf.as_slice()).unwrap();
   assert!(extra.0.is_empty());
 }
 
@@ -194,7 +194,7 @@ fn extra_mysterious_minergate_only_wrong_size() {
 fn extra_mysterious_minergate_and_pub_key() {
   let mut buf: Vec<u8> = vec![222, 1, 42];
   buf.extend(PUB_KEY_BYTES.to_vec());
-  let extra = Extra::read::<&[u8]>(&mut buf.as_ref()).unwrap();
+  let extra = Extra::read(&mut buf.as_slice()).unwrap();
   assert_eq!(
     extra.0,
     vec![ExtraField::MysteriousMinergate(vec![42]), ExtraField::PublicKey(pub_key())]

--- a/monero-oxide/wallet/src/tests/scan.rs
+++ b/monero-oxide/wallet/src/tests/scan.rs
@@ -127,10 +127,10 @@ fn scan_long_encrypted_amount() {
     Zeroizing::new(Scalar::from_canonical_bytes(view_key_buf.try_into().unwrap()).unwrap());
 
   let tx_buf = hex::decode(PRUNED_TX_WITH_LONG_ENCRYPTED_AMOUNT).unwrap();
-  let tx = Transaction::<Pruned>::read::<&[u8]>(&mut tx_buf.as_ref()).unwrap();
+  let tx = Transaction::<Pruned>::read(&mut tx_buf.as_slice()).unwrap();
 
   let block_buf = hex::decode(BLOCK).unwrap();
-  let block = Block::read::<&[u8]>(&mut block_buf.as_ref()).unwrap();
+  let block = Block::read(&mut block_buf.as_slice()).unwrap();
 
   // Confirm tx has long form encrypted amounts
   match &tx {

--- a/monero-oxide/wallet/src/view_pair.rs
+++ b/monero-oxide/wallet/src/view_pair.rs
@@ -54,8 +54,8 @@ impl ViewPair {
   pub(crate) fn subaddress_derivation(&self, index: SubaddressIndex) -> Scalar {
     keccak256_to_scalar(Zeroizing::new(
       [
-        b"SubAddr\0".as_ref(),
-        Zeroizing::new(self.view.to_bytes()).as_ref(),
+        b"SubAddr\0".as_slice(),
+        Zeroizing::new(self.view.to_bytes()).as_slice(),
         &index.account().to_le_bytes(),
         &index.address().to_le_bytes(),
       ]

--- a/monero-oxide/wallet/tests/eventuality.rs
+++ b/monero-oxide/wallet/tests/eventuality.rs
@@ -52,10 +52,7 @@ test!(
       );
       let tx = builder.build().unwrap();
       let eventuality = Eventuality::from(tx.clone());
-      assert_eq!(
-        eventuality,
-        Eventuality::read::<&[u8]>(&mut eventuality.serialize().as_ref()).unwrap()
-      );
+      assert_eq!(eventuality, Eventuality::read(&mut eventuality.serialize().as_slice()).unwrap());
       (tx, eventuality)
     },
     |_, _, mut tx: Transaction, _, eventuality: Eventuality| async move {

--- a/monero-oxide/wallet/tests/send.rs
+++ b/monero-oxide/wallet/tests/send.rs
@@ -152,12 +152,7 @@ test!(
       assert!(sub_outputs[0].subaddress().unwrap().address() == 1);
 
       // Make sure only one R was included in TX extra
-      assert!(Extra::read::<&[u8]>(&mut tx.prefix().extra.as_ref())
-        .unwrap()
-        .keys()
-        .unwrap()
-        .1
-        .is_none());
+      assert!(Extra::read(&mut tx.prefix().extra.as_slice()).unwrap().keys().unwrap().1.is_none());
     },
   ),
 );

--- a/monero-oxide/wallet/tests/wallet2_compatibility.rs
+++ b/monero-oxide/wallet/tests/wallet2_compatibility.rs
@@ -233,12 +233,7 @@ test!(
       assert_eq!(transfer.transfer.payment_id, hex::encode([0u8; 8]));
 
       // Make sure only one R was included in TX extra
-      assert!(Extra::read::<&[u8]>(&mut tx.prefix().extra.as_ref())
-        .unwrap()
-        .keys()
-        .unwrap()
-        .1
-        .is_none());
+      assert!(Extra::read(&mut tx.prefix().extra.as_slice()).unwrap().keys().unwrap().1.is_none());
     },
   ),
 );
@@ -291,8 +286,7 @@ test!(
       }
 
       // Make sure 3 additional pub keys are included in TX extra
-      let keys =
-        Extra::read::<&[u8]>(&mut tx.prefix().extra.as_ref()).unwrap().keys().unwrap().1.unwrap();
+      let keys = Extra::read(&mut tx.prefix().extra.as_slice()).unwrap().keys().unwrap().1.unwrap();
 
       assert_eq!(keys.len(), 3);
     },


### PR DESCRIPTION
Now, all usages are either explicitly typed _or_ of the form `Option<T> as AsRef<Option<&T>>`, which should be fine.

Hedges against dependencies introducing their own `AsRef` implementations, which would cause these to be ambiguous, such as discussed [here](
  https://github.com/RustCrypto/hybrid-array/issues/131
).