### PR TITLE
Check the amount of outs returned is equivalent to the amount asked for

### DIFF
--- a/monero-oxide/rpc/src/lib.rs
+++ b/monero-oxide/rpc/src/lib.rs
@@ -1233,6 +1233,10 @@ impl<R: Rpc> DecoyRpc for R {
           Err(RpcError::InvalidNode("bad response to get_outs".to_string()))?;
         }
 
+        if rpc_res.outs.len() != indexes.len() {
+          Err(RpcError::InvalidNode("get_outs response omitted requested outputs".to_string()))?;
+        }
+
         res.extend(
           rpc_res
             .outs


### PR DESCRIPTION
This is a minimal amount of validation which ensures the decoy RPC isn't borked by an active adversary who returns less outs than expected, enabling them to feasibly identify the real spend.