### PR TITLE
Remove `outgoing_view_key` from the `Debug` implementation on `SignableTransaction`

### DIFF
--- a/monero-oxide/ringct/bulletproofs/src/original/mod.rs
+++ b/monero-oxide/ringct/bulletproofs/src/original/mod.rs
@@ -27,7 +27,7 @@ pub(crate) struct AggregateRangeStatement<'a> {
   commitments: &'a [EdwardsPoint],
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct AggregateRangeWitness {
   commitments: Vec<Commitment>,
 }

--- a/monero-oxide/ringct/bulletproofs/src/plus/aggregate_range_proof.rs
+++ b/monero-oxide/ringct/bulletproofs/src/plus/aggregate_range_proof.rs
@@ -26,7 +26,7 @@ pub(crate) struct AggregateRangeStatement<'a> {
   V: &'a [EdwardsPoint],
 }
 
-#[derive(Clone, Debug, Zeroize, ZeroizeOnDrop)]
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub(crate) struct AggregateRangeWitness(Vec<Commitment>);
 
 impl AggregateRangeWitness {

--- a/monero-oxide/ringct/bulletproofs/src/plus/weighted_inner_product.rs
+++ b/monero-oxide/ringct/bulletproofs/src/plus/weighted_inner_product.rs
@@ -28,7 +28,7 @@ impl Zeroize for WipStatement {
   }
 }
 
-#[derive(Clone, Debug, Zeroize, ZeroizeOnDrop)]
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub(crate) struct WipWitness {
   a: ScalarVector,
   b: ScalarVector,

--- a/monero-oxide/wallet/src/output.rs
+++ b/monero-oxide/wallet/src/output.rs
@@ -95,9 +95,8 @@ impl core::fmt::Debug for OutputData {
     fmt
       .debug_struct("OutputData")
       .field("key", &hex::encode(self.key.compress().0))
-      .field("key_offset", &hex::encode(self.key_offset.to_bytes()))
       .field("commitment", &self.commitment)
-      .finish()
+      .finish_non_exhaustive()
   }
 }
 

--- a/monero-oxide/wallet/src/send/mod.rs
+++ b/monero-oxide/wallet/src/send/mod.rs
@@ -215,7 +215,7 @@ pub enum SendError {
 }
 
 /// A signable transaction.
-#[derive(Clone, PartialEq, Eq, Debug, Zeroize)]
+#[derive(Clone, PartialEq, Eq, Zeroize)]
 pub struct SignableTransaction {
   rct_type: RctType,
   outgoing_view_key: Zeroizing<[u8; 32]>,
@@ -223,6 +223,18 @@ pub struct SignableTransaction {
   payments: Vec<InternalPayment>,
   data: Vec<Vec<u8>>,
   fee_rate: FeeRate,
+}
+
+impl fmt::Debug for SignableTransaction {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    f.debug_struct("SignableTransaction")
+      .field("rct_type", &self.rct_type)
+      .field("inputs", &self.inputs)
+      .field("payments", &self.payments)
+      .field("data", &self.data)
+      .field("fee_rate", &self.fee_rate)
+      .finish_non_exhaustive()
+  }
 }
 
 struct SignableTransactionWithKeyImages {


### PR DESCRIPTION
Also removes `Debug` from Bulletproof witnesses, which are internal and mostly safe due to wrapping `Commitment` which has a safe `Debug` already, but shouldn't be marked `Debug`, and the `key_offset` from the wallet output information (a scalar which can be public but why print it?).

Fixes #70.