### PR TITLE
Extensively introduce internal bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +439,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +481,7 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -539,18 +534,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hex"
@@ -1429,10 +1424,11 @@ dependencies = [
 
 [[package]]
 name = "simple-request"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249660bdb65234c11f0eb69c0680096d8cc116897dbbeb8503269e469aad2fff"
+checksum = "ec88848b6c05daeedd338ba041d8f3a30dd57d4eeab028a7879b02be55141d6a"
 dependencies = [
+ "futures-util",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -1481,11 +1477,11 @@ dependencies = [
 
 [[package]]
 name = "std-shims"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fbb9ed849fede2765386134c64bc8984081e8c8408bc9201b99c6e3143ec5e7"
+checksum = "227c4f8561598188d0df96dbe749824576174bba278b5b6bb2eacff1066067d0"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.16.0",
  "rustversion",
  "spin",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,7 @@ allow = [
   "BSD-2-Clause",
   "BSD-3-Clause",
   "ISC",
+  "Zlib",
   "Unicode-DFS-2016",
   # "OpenSSL",
 

--- a/monero-oxide/Cargo.toml
+++ b/monero-oxide/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-std-shims = { version = "0.1.4", default-features = false }
+std-shims = { version = "0.1.5", default-features = false }
 
 zeroize = { version = "^1.5", default-features = false, features = ["zeroize_derive"] }
 

--- a/monero-oxide/generators/Cargo.toml
+++ b/monero-oxide/generators/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-std-shims = { version = "0.1.4", default-features = false }
+std-shims = { version = "0.1.5", default-features = false }
 
 subtle = { version = "^2.4", default-features = false }
 

--- a/monero-oxide/io/Cargo.toml
+++ b/monero-oxide/io/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-std-shims = { version = "0.1.4", default-features = false }
+std-shims = { version = "0.1.5", default-features = false }
 
 curve25519-dalek = { version = "4", default-features = false, features = ["alloc"] }
 

--- a/monero-oxide/io/src/compressed_point.rs
+++ b/monero-oxide/io/src/compressed_point.rs
@@ -1,6 +1,4 @@
-use std_shims::{
-  io::{self, Read, Write},
-};
+use std_shims::io::{self, Read, Write};
 
 use zeroize::Zeroize;
 

--- a/monero-oxide/io/src/lib.rs
+++ b/monero-oxide/io/src/lib.rs
@@ -6,11 +6,7 @@
 use core::fmt::Debug;
 #[allow(unused_imports)]
 use std_shims::prelude::*;
-use std_shims::{
-  vec,
-  vec::Vec,
-  io::{self, Read, Write},
-};
+use std_shims::io::{self, Read, Write};
 
 use curve25519_dalek::{scalar::Scalar, edwards::EdwardsPoint};
 
@@ -106,8 +102,8 @@ pub fn write_point<W: Write>(point: &EdwardsPoint, w: &mut W) -> io::Result<()> 
 }
 
 /// Write a list of elements, without length-prefixing.
-pub fn write_raw_vec<T, W: Write, F: Fn(&T, &mut W) -> io::Result<()>>(
-  f: F,
+pub fn write_raw_vec<T, W: Write, F: FnMut(&T, &mut W) -> io::Result<()>>(
+  mut f: F,
   values: &[T],
   w: &mut W,
 ) -> io::Result<()> {
@@ -118,7 +114,7 @@ pub fn write_raw_vec<T, W: Write, F: Fn(&T, &mut W) -> io::Result<()>>(
 }
 
 /// Write a list of elements, with length-prefixing.
-pub fn write_vec<T, W: Write, F: Fn(&T, &mut W) -> io::Result<()>>(
+pub fn write_vec<T, W: Write, F: FnMut(&T, &mut W) -> io::Result<()>>(
   f: F,
   values: &[T],
   w: &mut W,
@@ -192,8 +188,8 @@ pub fn read_point<R: Read>(r: &mut R) -> io::Result<EdwardsPoint> {
 }
 
 /// Read a variable-length list of elements, without length-prefixing.
-pub fn read_raw_vec<R: Read, T, F: Fn(&mut R) -> io::Result<T>>(
-  f: F,
+pub fn read_raw_vec<R: Read, T, F: FnMut(&mut R) -> io::Result<T>>(
+  mut f: F,
   len: usize,
   r: &mut R,
 ) -> io::Result<Vec<T>> {
@@ -205,7 +201,7 @@ pub fn read_raw_vec<R: Read, T, F: Fn(&mut R) -> io::Result<T>>(
 }
 
 /// Read a constant-length list of elements.
-pub fn read_array<R: Read, T: Debug, F: Fn(&mut R) -> io::Result<T>, const N: usize>(
+pub fn read_array<R: Read, T: Debug, F: FnMut(&mut R) -> io::Result<T>, const N: usize>(
   f: F,
   r: &mut R,
 ) -> io::Result<[T; N]> {
@@ -221,7 +217,7 @@ pub fn read_array<R: Read, T: Debug, F: Fn(&mut R) -> io::Result<T>, const N: us
 /// An optional bound on the length of the result may be provided. If `None`, the returned `Vec`
 /// will be of the length read off the reader, if successfully read. If `Some(_)`, an error will be
 /// raised if the length read off the read is greater than the bound.
-pub fn read_vec<R: Read, T, F: Fn(&mut R) -> io::Result<T>>(
+pub fn read_vec<R: Read, T, F: FnMut(&mut R) -> io::Result<T>>(
   f: F,
   length_bound: Option<usize>,
   r: &mut R,

--- a/monero-oxide/primitives/Cargo.toml
+++ b/monero-oxide/primitives/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-std-shims = { version = "0.1.4", default-features = false }
+std-shims = { version = "0.1.5", default-features = false }
 
 zeroize = { version = "^1.5", default-features = false, features = ["zeroize_derive"] }
 

--- a/monero-oxide/primitives/src/lib.rs
+++ b/monero-oxide/primitives/src/lib.rs
@@ -5,7 +5,7 @@
 
 #[allow(unused_imports)]
 use std_shims::prelude::*;
-use std_shims::{io, vec::Vec};
+use std_shims::io;
 #[cfg(feature = "std")]
 use std_shims::sync::LazyLock;
 
@@ -161,6 +161,14 @@ impl core::fmt::Debug for Decoys {
   }
 }
 
+/*
+  The max ring size the monero-oxide libraries is programmed to support.
+
+  This exceeds the current Monero protocol's ring size of `16`, with the next hard fork planned to
+  remove rings entirely, making this without issue.
+*/
+const MAX_RING_SIZE: usize = u8::MAX as usize;
+
 #[allow(clippy::len_without_is_empty)]
 impl Decoys {
   /// Create a new instance of decoy data.
@@ -168,7 +176,7 @@ impl Decoys {
   /// `offsets` are the positions of each ring member within the Monero blockchain, offset from the
   /// prior member's position (with the initial ring member offset from 0).
   pub fn new(offsets: Vec<u64>, signer_index: u8, ring: Vec<[EdwardsPoint; 2]>) -> Option<Self> {
-    if (offsets.len() > usize::from(u8::MAX)) ||
+    if (offsets.len() > MAX_RING_SIZE) ||
       (offsets.len() != ring.len()) ||
       (usize::from(signer_index) >= ring.len())
     {
@@ -252,7 +260,7 @@ impl Decoys {
   /// This is not a Monero protocol defined struct, and this is accordingly not a Monero protocol
   /// defined serialization.
   pub fn read(r: &mut impl io::Read) -> io::Result<Decoys> {
-    let offsets = read_vec(read_varint, None, r)?;
+    let offsets = read_vec(read_varint, Some(MAX_RING_SIZE), r)?;
     let len = offsets.len();
     Decoys::new(
       offsets,

--- a/monero-oxide/primitives/src/lib.rs
+++ b/monero-oxide/primitives/src/lib.rs
@@ -162,7 +162,7 @@ impl core::fmt::Debug for Decoys {
 }
 
 /*
-  The max ring size the monero-oxide libraries is programmed to support.
+  The max ring size the monero-oxide libraries is programmed to support creating.
 
   This exceeds the current Monero protocol's ring size of `16`, with the next hard fork planned to
   remove rings entirely, making this without issue.

--- a/monero-oxide/ringct/borromean/Cargo.toml
+++ b/monero-oxide/ringct/borromean/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-std-shims = { version = "0.1.4", default-features = false }
+std-shims = { version = "0.1.5", default-features = false }
 
 zeroize = { version = "^1.5", default-features = false, features = ["zeroize_derive"] }
 

--- a/monero-oxide/ringct/bulletproofs/Cargo.toml
+++ b/monero-oxide/ringct/bulletproofs/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-std-shims = { version = "0.1.4", default-features = false }
+std-shims = { version = "0.1.5", default-features = false }
 
 thiserror = { version = "2", default-features = false }
 

--- a/monero-oxide/ringct/clsag/Cargo.toml
+++ b/monero-oxide/ringct/clsag/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-std-shims = { version = "0.1.4", default-features = false }
+std-shims = { version = "0.1.5", default-features = false }
 
 thiserror = { version = "2", default-features = false }
 

--- a/monero-oxide/ringct/mlsag/Cargo.toml
+++ b/monero-oxide/ringct/mlsag/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-std-shims = { version = "0.1.4", default-features = false }
+std-shims = { version = "0.1.5", default-features = false }
 
 thiserror = { version = "2", default-features = false }
 

--- a/monero-oxide/ringct/mlsag/src/lib.rs
+++ b/monero-oxide/ringct/mlsag/src/lib.rs
@@ -113,9 +113,9 @@ impl Mlsag {
   }
 
   /// Read a MLSAG.
-  pub fn read<R: Read>(mixins: usize, ss_2_elements: usize, r: &mut R) -> io::Result<Mlsag> {
+  pub fn read<R: Read>(decoys: usize, ss_2_elements: usize, r: &mut R) -> io::Result<Mlsag> {
     Ok(Mlsag {
-      ss: (0 .. mixins)
+      ss: (0 .. decoys)
         .map(|_| read_raw_vec(read_scalar, ss_2_elements, r))
         .collect::<Result<_, _>>()?,
       cc: read_scalar(r)?,

--- a/monero-oxide/src/ringct.rs
+++ b/monero-oxide/src/ringct.rs
@@ -1,10 +1,6 @@
 #[allow(unused_imports)]
 use std_shims::prelude::*;
-use std_shims::{
-  vec,
-  vec::Vec,
-  io::{self, Read, Write},
-};
+use std_shims::io::{self, Read, Write};
 
 use zeroize::Zeroize;
 

--- a/monero-oxide/wallet/Cargo.toml
+++ b/monero-oxide/wallet/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/monero-oxide/monero-oxide/tree/main/monero-oxide/wallet"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.89"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/monero-oxide/wallet/Cargo.toml
+++ b/monero-oxide/wallet/Cargo.toml
@@ -19,7 +19,7 @@ ignored = ["monero-clsag"]
 workspace = true
 
 [dependencies]
-std-shims = { version = "0.1.4", default-features = false }
+std-shims = { version = "0.1.5", default-features = false }
 
 thiserror = { version = "2", default-features = false }
 

--- a/monero-oxide/wallet/base58/Cargo.toml
+++ b/monero-oxide/wallet/base58/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-std-shims = { version = "0.1.4", default-features = false }
+std-shims = { version = "0.1.5", default-features = false }
 monero-primitives = { path = "../../primitives", default-features = false }
 
 [dev-dependencies]

--- a/monero-oxide/wallet/base58/src/lib.rs
+++ b/monero-oxide/wallet/base58/src/lib.rs
@@ -3,9 +3,7 @@
 #![deny(missing_docs)]
 #![cfg_attr(not(test), no_std)]
 
-#[allow(unused)]
 use std_shims::prelude::*;
-use std_shims::{vec::Vec, string::String};
 
 use monero_primitives::keccak256;
 

--- a/monero-oxide/wallet/src/extra.rs
+++ b/monero-oxide/wallet/src/extra.rs
@@ -23,6 +23,11 @@ pub(crate) const ARBITRARY_DATA_MARKER: u8 = 127;
 // 1 byte is used for the marker
 pub const MAX_ARBITRARY_DATA_SIZE: usize = MAX_TX_EXTRA_NONCE_SIZE - 1;
 
+/// The maximum length for a transaction's extra under current relay rules.
+// https://github.com/monero-project/monero
+//  /blob/8d4c625713e3419573dfcc7119c8848f47cabbaa/src/cryptonote_config.h#L217
+pub const MAX_EXTRA_SIZE_BY_RELAY_RULE: usize = 1060;
+
 /// A Payment ID.
 ///
 /// This is a legacy method of identifying why Monero was sent to the receiver.
@@ -239,8 +244,14 @@ impl Extra {
   ///
   /// This uses a marker custom to monero-wallet.
   pub fn data(&self) -> Vec<Vec<u8>> {
+    // Only parse arbitrary data from the amount of extra data accepted under the relay rule
+    let serialized = self.serialize();
+    let bounded_extra =
+      Self::read(&mut &serialized[.. serialized.len().min(MAX_EXTRA_SIZE_BY_RELAY_RULE)])
+        .expect("`Extra::read` only fails if the IO fails and `&[u8]` won't");
+
     let mut res = vec![];
-    for field in &self.0 {
+    for field in &bounded_extra.0 {
       if let ExtraField::Nonce(data) = field {
         if data.first() == Some(&ARBITRARY_DATA_MARKER) {
           res.push(data[1 ..].to_vec());
@@ -262,6 +273,8 @@ impl Extra {
     res
   }
 
+  // TODO: This allows pushing a nonce of size greater than allowed. That's likely fine as it's
+  // internal, yet should be better?
   pub(crate) fn push_nonce(&mut self, nonce: Vec<u8>) {
     self.0.push(ExtraField::Nonce(nonce));
   }

--- a/monero-oxide/wallet/src/output.rs
+++ b/monero-oxide/wallet/src/output.rs
@@ -9,7 +9,11 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 use curve25519_dalek::{Scalar, edwards::EdwardsPoint};
 
 use crate::{
-  io::*, primitives::Commitment, transaction::Timelock, address::SubaddressIndex, extra::PaymentId,
+  io::*,
+  primitives::Commitment,
+  transaction::Timelock,
+  address::SubaddressIndex,
+  extra::{MAX_ARBITRARY_DATA_SIZE, MAX_EXTRA_SIZE_BY_RELAY_RULE, PaymentId},
 };
 
 /// An absolute output ID, defined as its transaction hash and output index.
@@ -194,14 +198,12 @@ impl Metadata {
       w.write_all(&[0])?;
     }
 
-    w.write_all(
-      &u64::try_from(self.arbitrary_data.len())
-        .expect("amount of arbitrary data chunks exceeded u64::MAX")
-        .to_le_bytes(),
-    )?;
+    write_varint(&self.arbitrary_data.len(), w)?;
     for part in &self.arbitrary_data {
       // TODO: Define our own collection whose `len` function returns `u8` to ensure this bound
       // with types
+      const _ASSERT_MAX_ARB_DATA_SIZE_FITS_WITHIN_U8: [();
+        (u8::MAX as usize) - MAX_ARBITRARY_DATA_SIZE] = [(); _];
       w.write_all(&[
         u8::try_from(part.len()).expect("piece of arbitrary data exceeded max length of u8::MAX")
       ])?;
@@ -230,11 +232,21 @@ impl Metadata {
       additional_timelock,
       subaddress,
       payment_id: if read_byte(r)? == 1 { PaymentId::read(r).ok() } else { None },
+      /*
+        This may technically read more `arbitrary_data` than can fit in actual transaction as it
+        only checks the arbitrary data, raw, will fit in an extra, with no other structure/fields.
+      */
       arbitrary_data: {
         let mut data = vec![];
-        for _ in 0 .. read_u64(r)? {
+        let mut total_len = 0usize;
+        for _ in 0 .. read_varint::<_, usize>(r)? {
           let len = read_byte(r)?;
-          data.push(read_raw_vec(read_byte, usize::from(len), r)?);
+          let chunk = read_raw_vec(read_byte, usize::from(len), r)?;
+          total_len = total_len.wrapping_add(chunk.len());
+          if total_len > MAX_EXTRA_SIZE_BY_RELAY_RULE {
+            Err(io::Error::other("amount of arbitrary data exceeded amount allowed by policy"))?;
+          }
+          data.push(chunk);
         }
         data
       },

--- a/monero-oxide/wallet/src/send/mod.rs
+++ b/monero-oxide/wallet/src/send/mod.rs
@@ -21,9 +21,9 @@ use crate::{
     clsag::{ClsagError, ClsagContext, Clsag},
     RctType, RctPrunable, RctProofs,
   },
-  transaction::Transaction,
+  transaction::{INPUTS_UPPER_BOUND, Transaction},
   address::{Network, SubaddressIndex, MoneroAddress},
-  extra::MAX_ARBITRARY_DATA_SIZE,
+  extra::{MAX_ARBITRARY_DATA_SIZE, MAX_EXTRA_SIZE_BY_RELAY_RULE},
   rpc::FeeRate,
   ViewPair, GuaranteedViewPair, OutputWithDecoys,
 };
@@ -294,9 +294,7 @@ impl SignableTransaction {
     }
 
     // Check the length of TX extra
-    // https://github.com/monero-project/monero/pull/8733
-    const MAX_EXTRA_SIZE: usize = 1060;
-    if self.extra().len() > MAX_EXTRA_SIZE {
+    if self.extra().len() > MAX_EXTRA_SIZE_BY_RELAY_RULE {
       Err(SendError::TooMuchArbitraryData)?;
     }
 
@@ -469,7 +467,43 @@ impl SignableTransaction {
   /// defined serialization.
   pub fn read<R: io::Read>(r: &mut R) -> io::Result<SignableTransaction> {
     fn read_address<R: io::Read>(r: &mut R) -> io::Result<MoneroAddress> {
-      String::from_utf8(read_vec(read_byte, None, r)?)
+      /*
+        This uses featured addresses for a bound as they'll always be potentially larger than
+        traditional addresses.
+
+        https://gist.github.com/kayabaNerve/01c50bbc35441e0bbdcee63a9d823789
+      */
+      const FEATURED_ADDRESS_DATA_SIZE_UPPER_BOUND: usize = 9 + 32 + 32 + 9 + 8;
+      // Checksum
+      const FEATURED_ADDRESS_CHECKED_DATA_SIZE_UPPER_BOUND: usize =
+        FEATURED_ADDRESS_DATA_SIZE_UPPER_BOUND + 4;
+      // Base58-encoding, using 5 for `log2(58)`
+      const FEATURED_ADDRESS_ENCODED_SIZE_UPPER_BOUND: usize =
+        (FEATURED_ADDRESS_CHECKED_DATA_SIZE_UPPER_BOUND * 8).div_ceil(5);
+
+      /*
+        https://gist.github.com/tevador
+          /50160d160d24cfc6c52ae02eb3d17024?permalink_comment_id=4744307#gistcomment-4744307
+        notes one JAMTIS proposal which used 247 bytes, while most are 244 bytes. JAMTIS-RCT is
+        244 (https://gist.github.com/tevador/d3656a217c0177c160b9b6219d9ebb96).
+      */
+      const JAMTIS_ADDRESS_ENCODED_SIZE: usize = 247;
+
+      const fn const_max(a: usize, b: usize) -> usize {
+        if a > b {
+          a
+        } else {
+          b
+        }
+      }
+      const ADDRESS_ENCODED_SIZE_UPPER_BOUND: usize =
+        const_max(FEATURED_ADDRESS_ENCODED_SIZE_UPPER_BOUND, JAMTIS_ADDRESS_ENCODED_SIZE);
+
+      const ADDRESS_ENCODED_SIZE_SAFETY_FACTOR: usize = 2;
+      const ADDRESS_ENCODED_SIZE_BOUND: usize =
+        ADDRESS_ENCODED_SIZE_SAFETY_FACTOR * ADDRESS_ENCODED_SIZE_UPPER_BOUND;
+
+      String::from_utf8(read_vec(read_byte, Some(ADDRESS_ENCODED_SIZE_BOUND), r)?)
         .ok()
         .and_then(|str| MoneroAddress::from_str_with_unchecked_network(&str).ok())
         .ok_or_else(|| io::Error::other("invalid address"))
@@ -497,9 +531,17 @@ impl SignableTransaction {
       rct_type: RctType::try_from(read_byte(r)?)
         .map_err(|()| io::Error::other("unsupported/invalid RctType"))?,
       outgoing_view_key: Zeroizing::new(read_bytes(r)?),
-      inputs: read_vec(OutputWithDecoys::read, None, r)?,
-      payments: read_vec(read_payment, None, r)?,
-      data: read_vec(|r| read_vec(read_byte, None, r), None, r)?,
+      inputs: read_vec(OutputWithDecoys::read, Some(INPUTS_UPPER_BOUND), r)?,
+      payments: read_vec(read_payment, Some(MAX_BULLETPROOF_COMMITMENTS), r)?,
+      /*
+        This doesn't assert the _total_ length is `< MAX_EXTRA_SIZE_BY_RELAY_RULE`, yet the
+        following call to `validate` will.
+      */
+      data: read_vec(
+        |r| read_vec(read_byte, Some(MAX_ARBITRARY_DATA_SIZE), r),
+        Some(MAX_EXTRA_SIZE_BY_RELAY_RULE),
+        r,
+      )?,
       fee_rate: FeeRate::read(r)?,
     };
     match res.validate() {

--- a/tests/no-std/Cargo.toml
+++ b/tests/no-std/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 keywords = ["nostd", "no_std", "alloc"]
 edition = "2021"
 publish = false
-rust-version = "1.75"
+rust-version = "1.89"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Resolves https://github.com/monero-oxide/monero-oxide/issues/72.

This commit's most notable changes are to `monero-io`, which has been widened to accept `FnMut` over `Fn` (as all `Fn` are `FnMut`), and to the handling of arbitrary data as defined in `monero-wallet`.

Prior, `monero-wallet` would only create transactions whose extra was less than the limit imposed by a relay limit, yet would accept arbitrary data from an extra of any size. Now, when parsing arbitrary data out of a transaction, only the arbitrary data fields within the first 1060 bytes are considered. This lets us establish a bound on the amount of arbitrary data despite extra itself being unbounded. The serialization of `Metadata` has also been adjusted to use a `VarInt` over a `u64`.

The bump to the version of `std-shims` is required for `impl<R: Read> Read for &mut R`, which is used inside the new `Transaction::read` function (which now enforces a maximum byte length on non-miner transactions).

Split out of https://github.com/monero-oxide/monero-oxide/pull/66. Specifically, this represents the following commits:

commit e041ad78e1c209ba5a66e7f62f3bd87ae650093e
Fix `no-std` builds

---

commit 2ab2db1bce641f1610dd7729fdcc4542d8b7f55d
Update citation for the TX extra relay rule now that it's merged

Also adds a test for the new limit on arbitrary data, and prefers `_SIZE` to `_LEN` in constants I've declared.

---

commit 57d5bca53f2ec710539ee790cd8a7798669a07df
Bound the size of addresses when deserializing a `SignableTransaction`

---

commit 63cc9361403bc9b6d7837eea531fe208894154d4
Introduce length bound on the size of an address string with `SignableTransaction` deserialization

---

commit 1eebe1949d9af58971ac0a92d106ceb747cb61a3
Rename `MAX_INPUTS` to `INPUTS_UPPER_BOUND`, as it isn't accurate

Also uses it within `SignableTransaction` deserialization.

---

commit 3f03b0f9a8042ac2f58cfcd52166a8768c7b852e
Introduce bound to `Decoys` during deserialization

---

commit 123288e509d41a36940f2249b2b1d97b09a94285
Bound the total amount of arbitrary data to the relay rule for the maximum size for a transaction's extra

Changes the encoding of `arbitrary_data` within `Metadata` to use a varint for a prefix, not a `u64`.

---

commit f364cfac53e95264d3d111ea76875dcdca1b3d30
Add `MAX_NON_MINER_TRANSACTION_SIZE` and `MAX_INPUTS`

Uses these bounds within `read_vec` calls in the transaction module where possible.

---

commit b1e6dc030662ba6e9418a5216332e95c7701c852
Widen `Fn` bounds to `FnMut` in `monero-io`

This allows more flexibility to callers and works as all `Fn` are also `FnMut`.