### PR TITLE
Better document arbitrary data

### DIFF
--- a/monero-oxide/wallet/src/extra.rs
+++ b/monero-oxide/wallet/src/extra.rs
@@ -265,6 +265,12 @@ impl Extra {
   /// Applications SHOULD include arbitrary data indistinguishable from random, of a popular length
   /// (such as padded to the next power of two or the maximum length per chunk) IF arbitrary data
   /// is included at all.
+  ///
+  /// For applications where indistinguishability from 'regular' Monero transactions is required,
+  /// steganography should be considered. Steganography is somewhat-frowned upon however due to it
+  /// bloating the Monero blockchain however and efficient methods are likely specific to
+  /// individual hard forks. They may also have their own privacy implications, which is why no
+  /// methods of stegnography are supported outright by `monero-wallet`.
   pub fn arbitrary_data(&self) -> Vec<Vec<u8>> {
     // Only parse arbitrary data from the amount of extra data accepted under the relay rule
     let serialized = self.serialize();

--- a/monero-oxide/wallet/src/extra.rs
+++ b/monero-oxide/wallet/src/extra.rs
@@ -251,8 +251,21 @@ impl Extra {
 
   /// The arbitrary data within this extra.
   ///
-  /// This uses a marker custom to monero-wallet.
-  pub fn data(&self) -> Vec<Vec<u8>> {
+  /// This looks for all instances of `ExtraField::Nonce` with a marker byte of 0b0111_1111. This
+  /// is the largest possible value not interpretable as a VarInt, ensuring it's able to be
+  /// interpreted as a VarInt without issue, and that it's the most unlikely value to be used by
+  /// the Monero wallet protocol itself (which itself has assigned marker bytes incrementally). As
+  /// Monero itself does not support including arbitrary data with its wallet however, this was
+  /// first introduced by `monero-wallet` (under the monero-oxide project) and may be bespoke to
+  /// the ecosystem of monero-oxide and dependents of it.
+  ///
+  /// The data is stored without any padding or encryption applied. Applications MUST consider this
+  /// themselves. As Monero does not reserve any space for arbitrary data, the inclusion of _any_
+  /// arbitrary data will _always_ be a fingerprint even before considering what the data is.
+  /// Applications SHOULD include arbitrary data indistinguishable from random, of a popular length
+  /// (such as padded to the next power of two or the maximum length per chunk) IF arbitrary data
+  /// is included at all.
+  pub fn arbitrary_data(&self) -> Vec<Vec<u8>> {
     // Only parse arbitrary data from the amount of extra data accepted under the relay rule
     let serialized = self.serialize();
     let bounded_extra =

--- a/monero-oxide/wallet/src/scan.rs
+++ b/monero-oxide/wallet/src/scan.rs
@@ -245,7 +245,7 @@ impl InternalScanner {
             additional_timelock: tx.prefix().additional_timelock,
             subaddress,
             payment_id,
-            arbitrary_data: extra.data(),
+            arbitrary_data: extra.arbitrary_data(),
           },
         });
 

--- a/monero-oxide/wallet/src/send/mod.rs
+++ b/monero-oxide/wallet/src/send/mod.rs
@@ -368,8 +368,7 @@ impl SignableTransaction {
   /// across incompatible transactions accordingly.
   ///
   /// `data` represents arbitrary data which will be embedded into the transaction's `extra` field.
-  /// The embedding occurs using an `ExtraField::Nonce` with a custom marker byte (as to not
-  /// conflict with a payment ID).
+  /// Please see `Extra::arbitrary_data` for the full impacts of this.
   pub fn new(
     rct_type: RctType,
     outgoing_view_key: Zeroizing<[u8; 32]>,

--- a/monero-oxide/wallet/src/tests/extra.rs
+++ b/monero-oxide/wallet/src/tests/extra.rs
@@ -207,9 +207,9 @@ fn extra_mysterious_minergate_and_pub_key() {
 
 #[test]
 fn fetching_data_does_not_panic() {
-  assert!(Extra::read(&mut [0x02, 0x00].as_slice()).unwrap().data().is_empty());
+  assert!(Extra::read(&mut [0x02, 0x00].as_slice()).unwrap().arbitrary_data().is_empty());
   assert_eq!(
-    Extra::read(&mut [0x02, 0x01, 0x7F].as_slice()).unwrap().data(),
+    Extra::read(&mut [0x02, 0x01, 0x7F].as_slice()).unwrap().arbitrary_data(),
     vec![Vec::<u8>::new()]
   );
 }
@@ -237,5 +237,5 @@ fn fetching_long_data_does_not_panic() {
   // The extra should encode and decode
   assert_eq!(Extra::read(&mut extra.serialize().as_slice()).unwrap(), extra);
   // Yet we should only read arbitrary data from the set within policy
-  assert_eq!(extra.data().len(), 5);
+  assert_eq!(extra.arbitrary_data().len(), 5);
 }


### PR DESCRIPTION
`monero-wallet` already documented a byte _custom to `monero-wallet`_ was used. Accordingly, while arbitrary data was a fingerprint (as it fundamentally is), it was a _documented_ fingerprint.

However, despite already saying it was a marker custom to `monero-wallet`, we could have better documented the method it was embedded with and the considerations relevant.

This clearly details the protocol and puts forth a RECOMMENDED format for any arbitrary data (padded, indistinguishable from random).