### PR TITLE
Update to `simple-request 0.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "simple-request"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec88848b6c05daeedd338ba041d8f3a30dd57d4eeab028a7879b02be55141d6a"
+checksum = "5c2b7792ed2409a25b01606121e65579dcacbc574e90f275a8cb6a4d78006986"
 dependencies = [
  "futures-util",
  "http-body-util",

--- a/monero-oxide/rpc/simple-request/Cargo.toml
+++ b/monero-oxide/rpc/simple-request/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 zeroize = { version = "^1.5", default-features = false, features = ["alloc", "std"] }
 digest_auth = { version = "0.3", default-features = false }
-simple-request = { version = "0.1", default-features = false, features = ["tls"] }
+simple-request = { version = "0.2", default-features = false, features = ["tls"] }
 tokio = { version = "1", default-features = false }
 
 monero-rpc = { path = "..", default-features = false, features = ["std"] }

--- a/monero-oxide/rpc/simple-request/src/lib.rs
+++ b/monero-oxide/rpc/simple-request/src/lib.rs
@@ -120,7 +120,9 @@ impl SimpleRequestRpc {
         connection: Arc::new(Mutex::new((challenge, client))),
       }
     } else {
-      Authentication::Unauthenticated(Client::with_connection_pool())
+      Authentication::Unauthenticated(Client::with_connection_pool().map_err(|e| {
+        RpcError::InternalError(format!("couldn't create a connection pool: {e:?}"))
+      })?)
     };
 
     Ok(SimpleRequestRpc { authentication, url, request_timeout })


### PR DESCRIPTION
This was already fixed with #66, but this is prioritized now to resolve the failing deny CI.