### PR TITLE
Introduce `UpperBound`, `LowerBound` to represent bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,6 +814,7 @@ dependencies = [
  "hex-literal",
  "monero-base58",
  "monero-io",
+ "monero-primitives",
  "rand_core",
  "serde",
  "serde_json",

--- a/monero-oxide/primitives/src/bounds.rs
+++ b/monero-oxide/primitives/src/bounds.rs
@@ -3,7 +3,7 @@
   and copying these docstrings would be very annoying.
 */
 
-/// A constant-time variant of the `max` function.
+/// A `const`-context variant of the `max` function.
 ///
 /// This is hidden as it's not to be considered part of our API commitment and is not guaranteed to
 /// be available/usable. It's implemented as a macro to work with any type, as we can't express an
@@ -20,7 +20,7 @@ macro_rules! const_max {
   };
 }
 
-/// A constant-time variant of the `min` function.
+/// A `const`-context variant of the `min` function.
 ///
 /// This is hidden as it's not to be considered part of our API commitment and is not guaranteed to
 /// be available/usable. It's implemented as a macro to work with any type, as we can't express an

--- a/monero-oxide/primitives/src/bounds.rs
+++ b/monero-oxide/primitives/src/bounds.rs
@@ -1,0 +1,59 @@
+/*
+  These structs exist just to consolidate documentation. We define these bounds in several places
+  and copying these docstrings would be very annoying.
+*/
+
+/// A constant-time variant of the `max` function.
+///
+/// This is hidden as it's not to be considered part of our API commitment and is not guaranteed to
+/// be available/usable. It's implemented as a macro to work with any type, as we can't express an
+/// `Ord` bound within a `const` context.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! const_max {
+  ($a: expr, $b: expr) => {
+    if $a > $b {
+      $a
+    } else {
+      $b
+    }
+  };
+}
+
+/// A constant-time variant of the `min` function.
+///
+/// This is hidden as it's not to be considered part of our API commitment and is not guaranteed to
+/// be available/usable. It's implemented as a macro to work with any type, as we can't express an
+/// `Ord` bound within a `const` context.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! const_min {
+  ($a: expr, $b: expr) => {
+    if $a < $b {
+      $a
+    } else {
+      $b
+    }
+  };
+}
+
+/// An upper bound for a value.
+///
+/// This is not guaranteed to be the minimal upper bound, solely a correct bound. This is not
+/// guaranteed to be a bound stable throughout the lifetime of the entire Monero protocol, solely
+/// as of the targeted version of the Monero protocol. It is intended to be used for size hints.
+/// Changes to this value, whether decreasing it to be closer to the actual bound or increasing it
+/// in response to a new version of the protocol, will not be considered breaking changes under
+/// SemVer.
+pub struct UpperBound<U>(pub U);
+
+/// A lower bound for a value.
+///
+/// This is not guaranteed to be the maximal lower bound, solely a correct bound (meaning `0` would
+/// always be acceptable). This is not guaranteed to be a bound stable throughout the lifetime of
+/// the entire Monero protocol, solely as of the targeted version of the Monero protocol. It is
+/// intended to be used for size hints. Changes to this value, whether increasing it to be closer
+/// to the actual bound or decreasing it in response to a new version of the protocol, will not be
+/// considered breaking changes under
+/// SemVer.
+pub struct LowerBound<U>(pub U);

--- a/monero-oxide/primitives/src/lib.rs
+++ b/monero-oxide/primitives/src/lib.rs
@@ -22,6 +22,9 @@ use curve25519_dalek::{
 use monero_io::*;
 use monero_generators::H;
 
+mod bounds;
+pub use bounds::*;
+
 mod unreduced_scalar;
 pub use unreduced_scalar::UnreducedScalar;
 

--- a/monero-oxide/wallet/address/Cargo.toml
+++ b/monero-oxide/wallet/address/Cargo.toml
@@ -23,6 +23,7 @@ zeroize = { version = "^1.5", default-features = false, features = ["zeroize_der
 curve25519-dalek = { version = "4", default-features = false, features = ["alloc", "zeroize"] }
 
 monero-io = { path = "../../io", default-features = false }
+monero-primitives = { path = "../../primitives", default-features = false }
 monero-base58 = { path = "../base58", default-features = false }
 
 [dev-dependencies]
@@ -41,6 +42,7 @@ std = [
   "zeroize/std",
 
   "monero-io/std",
+  "monero-primitives/std",
   "monero-base58/std",
 ]
 default = ["std"]

--- a/monero-oxide/wallet/address/Cargo.toml
+++ b/monero-oxide/wallet/address/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/monero-oxide/monero-oxide/tree/main/monero-oxide/wallet/address"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
-rust-version = "1.66"
+rust-version = "1.73"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/monero-oxide/wallet/src/send/mod.rs
+++ b/monero-oxide/wallet/src/send/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     clsag::{ClsagError, ClsagContext, Clsag},
     RctType, RctPrunable, RctProofs,
   },
-  transaction::{INPUTS_UPPER_BOUND, Transaction},
+  transaction::{TransactionPrefix, Transaction},
   address::{Network, SubaddressIndex, MoneroAddress},
   extra::{MAX_ARBITRARY_DATA_SIZE, MAX_EXTRA_SIZE_BY_RELAY_RULE},
   rpc::FeeRate,
@@ -483,44 +483,7 @@ impl SignableTransaction {
   /// defined serialization.
   pub fn read<R: io::Read>(r: &mut R) -> io::Result<SignableTransaction> {
     fn read_address<R: io::Read>(r: &mut R) -> io::Result<MoneroAddress> {
-      /*
-        This uses featured addresses for a bound as they'll always be potentially larger than
-        traditional addresses.
-
-        https://gist.github.com/kayabaNerve/01c50bbc35441e0bbdcee63a9d823789
-      */
-      const FEATURED_ADDRESS_DATA_SIZE_UPPER_BOUND: usize =
-        <u64 as VarInt>::UPPER_BOUND + 32 + 32 + <u64 as VarInt>::UPPER_BOUND + 8;
-      // Checksum
-      const FEATURED_ADDRESS_CHECKED_DATA_SIZE_UPPER_BOUND: usize =
-        FEATURED_ADDRESS_DATA_SIZE_UPPER_BOUND + 4;
-      // Base58-encoding, using 5 for `log2(58)`
-      const FEATURED_ADDRESS_ENCODED_SIZE_UPPER_BOUND: usize =
-        (FEATURED_ADDRESS_CHECKED_DATA_SIZE_UPPER_BOUND * 8).div_ceil(5);
-
-      /*
-        https://gist.github.com/tevador
-          /50160d160d24cfc6c52ae02eb3d17024?permalink_comment_id=4744307#gistcomment-4744307
-        notes one JAMTIS proposal which used 247 bytes, while most are 244 bytes. JAMTIS-RCT is
-        244 (https://gist.github.com/tevador/d3656a217c0177c160b9b6219d9ebb96).
-      */
-      const JAMTIS_ADDRESS_ENCODED_SIZE: usize = 247;
-
-      const fn const_max(a: usize, b: usize) -> usize {
-        if a > b {
-          a
-        } else {
-          b
-        }
-      }
-      const ADDRESS_ENCODED_SIZE_UPPER_BOUND: usize =
-        const_max(FEATURED_ADDRESS_ENCODED_SIZE_UPPER_BOUND, JAMTIS_ADDRESS_ENCODED_SIZE);
-
-      const ADDRESS_ENCODED_SIZE_SAFETY_FACTOR: usize = 2;
-      const ADDRESS_ENCODED_SIZE_BOUND: usize =
-        ADDRESS_ENCODED_SIZE_SAFETY_FACTOR * ADDRESS_ENCODED_SIZE_UPPER_BOUND;
-
-      String::from_utf8(read_vec(read_byte, Some(ADDRESS_ENCODED_SIZE_BOUND), r)?)
+      String::from_utf8(read_vec(read_byte, Some(MoneroAddress::SIZE_UPPER_BOUND.0), r)?)
         .ok()
         .and_then(|str| MoneroAddress::from_str_with_unchecked_network(&str).ok())
         .ok_or_else(|| io::Error::other("invalid address"))
@@ -548,7 +511,7 @@ impl SignableTransaction {
       rct_type: RctType::try_from(read_byte(r)?)
         .map_err(|()| io::Error::other("unsupported/invalid RctType"))?,
       outgoing_view_key: Zeroizing::new(read_bytes(r)?),
-      inputs: read_vec(OutputWithDecoys::read, Some(INPUTS_UPPER_BOUND), r)?,
+      inputs: read_vec(OutputWithDecoys::read, Some(TransactionPrefix::INPUTS_UPPER_BOUND.0), r)?,
       payments: read_vec(read_payment, Some(MAX_BULLETPROOF_COMMITMENTS), r)?,
       /*
         This doesn't assert the _total_ length is `< MAX_EXTRA_SIZE_BY_RELAY_RULE`, yet the


### PR DESCRIPTION
The docstrings on the structs are quite extensive, and we want them applied to all instantiations of a bound. Copying these docstrings everywhere would be annoying. This seemed to be the best solution.