### PR TITLE
Remove comments asking for a `Vec` whose length is a `u8`

### DIFF
--- a/monero-oxide/wallet/src/decoys.rs
+++ b/monero-oxide/wallet/src/decoys.rs
@@ -245,8 +245,6 @@ async fn select_decoys<R: RngCore + CryptoRng>(
     Decoys::new(
       offsets,
       // Binary searches for the real spend since we don't know where it sorted to
-      // TODO: Define our own collection whose `len` function returns `u8` to ensure this bound
-      // with types
       u8::try_from(ring.partition_point(|x| x.0 < input.relative_id.index_on_blockchain))
         .expect("ring of size <= u8::MAX had an index exceeding u8::MAX"),
       ring.into_iter().map(|output| output.1).collect(),

--- a/monero-oxide/wallet/src/output.rs
+++ b/monero-oxide/wallet/src/output.rs
@@ -199,9 +199,7 @@ impl Metadata {
 
     write_varint(&self.arbitrary_data.len(), w)?;
     for part in &self.arbitrary_data {
-      // TODO: Define our own collection whose `len` function returns `u8` to ensure this bound
-      // with types
-      const _ASSERT_MAX_ARB_DATA_SIZE_FITS_WITHIN_U8: [();
+      const _ASSERT_MAX_ARBITRARY_DATA_SIZE_FITS_WITHIN_U8: [();
         (u8::MAX as usize) - MAX_ARBITRARY_DATA_SIZE] = [(); _];
       w.write_all(&[
         u8::try_from(part.len()).expect("piece of arbitrary data exceeded max length of u8::MAX")


### PR DESCRIPTION
I have tried this and it is not worth the effort.