### PR TITLE
Tweak `VarInt`

### DIFF
--- a/monero-oxide/generators/src/lib.rs
+++ b/monero-oxide/generators/src/lib.rs
@@ -9,7 +9,7 @@ use sha3::{Digest, Keccak256};
 
 use curve25519_dalek::{constants::ED25519_BASEPOINT_POINT, edwards::EdwardsPoint};
 
-use monero_io::{write_varint, CompressedPoint};
+use monero_io::{VarInt, CompressedPoint};
 
 mod hash_to_point;
 pub use hash_to_point::biased_hash_to_point;
@@ -79,11 +79,11 @@ pub fn bulletproofs_generators(dst: &'static [u8]) -> Generators {
     let i = 2 * i;
 
     let mut even = preimage.clone();
-    write_varint(&i, &mut even).expect("write failed but <Vec as io::Write> doesn't fail");
+    VarInt::write(&i, &mut even).expect("write failed but <Vec as io::Write> doesn't fail");
     res.H.push(biased_hash_to_point(keccak256(&even)));
 
     let mut odd = preimage.clone();
-    write_varint(&(i + 1), &mut odd).expect("write failed but <Vec as io::Write> doesn't fail");
+    VarInt::write(&(i + 1), &mut odd).expect("write failed but <Vec as io::Write> doesn't fail");
     res.G.push(biased_hash_to_point(keccak256(&odd)));
   }
   res

--- a/monero-oxide/io/src/varint.rs
+++ b/monero-oxide/io/src/varint.rs
@@ -1,0 +1,158 @@
+//! Monero's VarInt type, frequently used to encode integers expected to be of low norm.
+//!
+//! This corresponds to
+//! https://github.com/monero-project/monero/blob/8e9ab9677f90492bca3c7555a246f2a8677bd570
+//!   /src/common/varint.h.
+
+#[allow(unused_imports)]
+use std_shims::prelude::*;
+use std_shims::io::{self, Read, Write};
+
+use crate::{read_byte, write_byte};
+
+const VARINT_CONTINUATION_FLAG: u8 = 0b1000_0000;
+const VARINT_VALUE_MASK: u8 = !VARINT_CONTINUATION_FLAG;
+
+mod sealed {
+  /// A seal to prevent implementing `VarInt` on foreign types.
+  pub trait Sealed {
+    /// Lossless, guaranteed conversion into a `u64`.
+    ///
+    /// This is due to internally implementing encoding for `u64` alone and `usize` not implementing
+    /// `From<u64>`.
+    // This is placed here so it's not within our public API commitment.
+    fn into_u64(self) -> u64;
+  }
+}
+
+/// Compute the upper bound for the encoded length of a integer type as a VarInt.
+///
+/// This is a private function only called at compile-time, hence why it panics on unexpected
+/// input.
+#[allow(clippy::cast_possible_truncation)]
+const fn upper_bound(bits: u32) -> usize {
+  // This assert ensures the following cast is correct even on 8-bit platforms
+  assert!(bits <= 256, "defining a number exceeding u256 as a VarInt");
+  // Manually implement `div_ceil` as it was introduced with 1.73 and `std-shims` cannot provide
+  // a `const fn` shim due to using a trait to provide this as a method
+  ((bits + (7 - 1)) / 7) as usize
+}
+
+/// A trait for a number readable/writable as a VarInt.
+///
+/// This is sealed to prevent unintended implementations. It MUST only be implemented for primitive
+/// types (or sufficiently approximate types like `NonZero<_>`).
+pub trait VarInt: TryFrom<u64> + Copy + sealed::Sealed {
+  /// The lower bound on the amount of bytes this will take up when encoded.
+  const LOWER_BOUND: usize;
+
+  /// The upper bound on the amount of bytes this will take up when encoded.
+  const UPPER_BOUND: usize;
+
+  /// The amount of bytes this number will take when serialized as a VarInt.
+  fn varint_len(self) -> usize {
+    let varint_u64 = self.into_u64();
+    usize::try_from(u64::BITS - varint_u64.leading_zeros()).expect("64 > usize::MAX?").div_ceil(7)
+  }
+
+  /// Read a canonically-encoded VarInt.
+  fn read<R: Read>(r: &mut R) -> io::Result<Self> {
+    let mut bits = 0;
+    let mut res = 0;
+    while {
+      let b = read_byte(r)?;
+      // Reject trailing zero bytes
+      // https://github.com/monero-project/monero/blob/8e9ab9677f90492bca3c7555a246f2a8677bd570
+      //   /src/common/varint.h#L107
+      if (bits != 0) && (b == 0) {
+        Err(io::Error::other("non-canonical varint"))?;
+      }
+
+      // We use `size_of` here as we control what `VarInt` is implemented for, and it's only for
+      // types whose size correspond to their range
+      #[allow(non_snake_case)]
+      let U_BITS = core::mem::size_of::<Self>() * 8;
+      if ((bits + 7) >= U_BITS) && (b >= (1 << (U_BITS - bits))) {
+        Err(io::Error::other("varint overflow"))?;
+      }
+
+      res += u64::from(b & VARINT_VALUE_MASK) << bits;
+      bits += 7;
+      (b & VARINT_CONTINUATION_FLAG) == VARINT_CONTINUATION_FLAG
+    } {}
+    res.try_into().map_err(|_| io::Error::other("VarInt does not fit into integer type"))
+  }
+
+  /// Encode a number as a VarInt.
+  ///
+  /// This doesn't accept `self` to force writing it as `VarInt::write`, making it clear it's being
+  /// written with the VarInt encoding.
+  fn write<W: Write>(varint: &Self, w: &mut W) -> io::Result<()> {
+    let mut varint: u64 = varint.into_u64();
+
+    // A do-while loop as we always encode at least one byte
+    while {
+      // Take the next seven bits
+      let mut b = u8::try_from(varint & u64::from(VARINT_VALUE_MASK))
+        .expect("& 0b0111_1111 left more than 8 bits set");
+      varint >>= 7;
+
+      // If there's more, set the continuation flag
+      if varint != 0 {
+        b |= VARINT_CONTINUATION_FLAG;
+      }
+
+      // Write this byte
+      write_byte(&b, w)?;
+
+      // Continue until the number is fully encoded
+      varint != 0
+    } {}
+
+    Ok(())
+  }
+}
+
+impl sealed::Sealed for u8 {
+  fn into_u64(self) -> u64 {
+    self.into()
+  }
+}
+impl VarInt for u8 {
+  const LOWER_BOUND: usize = 1;
+  const UPPER_BOUND: usize = upper_bound(Self::BITS);
+}
+
+impl sealed::Sealed for u32 {
+  fn into_u64(self) -> u64 {
+    self.into()
+  }
+}
+impl VarInt for u32 {
+  const LOWER_BOUND: usize = 1;
+  const UPPER_BOUND: usize = upper_bound(Self::BITS);
+}
+
+impl sealed::Sealed for u64 {
+  fn into_u64(self) -> u64 {
+    self
+  }
+}
+impl VarInt for u64 {
+  const LOWER_BOUND: usize = 1;
+  const UPPER_BOUND: usize = upper_bound(Self::BITS);
+}
+
+impl sealed::Sealed for usize {
+  fn into_u64(self) -> u64 {
+    // Ensure the falling conversion is infallible
+    const _NO_128_BIT_PLATFORMS: [(); (u64::BITS - usize::BITS) as usize] =
+      [(); (u64::BITS - usize::BITS) as usize];
+
+    self.try_into().expect("compiling on platform with <64-bit usize yet value didn't fit in u64")
+  }
+}
+impl VarInt for usize {
+  const LOWER_BOUND: usize = 1;
+  const UPPER_BOUND: usize = upper_bound(Self::BITS);
+}

--- a/monero-oxide/primitives/src/lib.rs
+++ b/monero-oxide/primitives/src/lib.rs
@@ -232,7 +232,7 @@ impl Decoys {
   /// This is not a Monero protocol defined struct, and this is accordingly not a Monero protocol
   /// defined serialization.
   pub fn write(&self, w: &mut impl io::Write) -> io::Result<()> {
-    write_vec(write_varint, &self.offsets, w)?;
+    write_vec(VarInt::write, &self.offsets, w)?;
     w.write_all(&[self.signer_index])?;
     write_raw_vec(
       |pair, w| {
@@ -260,7 +260,7 @@ impl Decoys {
   /// This is not a Monero protocol defined struct, and this is accordingly not a Monero protocol
   /// defined serialization.
   pub fn read(r: &mut impl io::Read) -> io::Result<Decoys> {
-    let offsets = read_vec(read_varint, Some(MAX_RING_SIZE), r)?;
+    let offsets = read_vec(VarInt::read, Some(MAX_RING_SIZE), r)?;
     let len = offsets.len();
     Decoys::new(
       offsets,

--- a/monero-oxide/src/block.rs
+++ b/monero-oxide/src/block.rs
@@ -183,9 +183,9 @@ impl Block {
   /// Get the hash of this block.
   pub fn hash(&self) -> [u8; 32] {
     let mut hashable = self.serialize_pow_hash();
-    // Monero pre-appends a VarInt of the block-to-hash'ss length before getting the block hash,
+    // Monero pre-appends a VarInt of the block-to-hash's length before getting the block hash,
     // but doesn't do this when getting the proof of work hash :)
-    let mut hashing_blob = Vec::with_capacity(9 + hashable.len());
+    let mut hashing_blob = Vec::with_capacity(<usize as VarInt>::UPPER_BOUND + hashable.len());
     VarInt::write(
       &u64::try_from(hashable.len()).expect("length of block hash's preimage exceeded u64::MAX"),
       &mut hashing_blob,

--- a/monero-oxide/src/transaction.rs
+++ b/monero-oxide/src/transaction.rs
@@ -133,7 +133,7 @@ impl Output {
 
   /// Write the Output to a `Vec<u8>`.
   pub fn serialize(&self) -> Vec<u8> {
-    let mut res = Vec::with_capacity(8 + 1 + 32);
+    let mut res = Vec::with_capacity(<u64 as VarInt>::UPPER_BOUND + 1 + 32 + 1);
     self.write(&mut res).expect("write failed but <Vec as io::Write> doesn't fail");
     res
   }

--- a/monero-oxide/src/transaction.rs
+++ b/monero-oxide/src/transaction.rs
@@ -65,13 +65,13 @@ impl Input {
     match self {
       Input::Gen(height) => {
         w.write_all(&[255])?;
-        write_varint(height, w)
+        VarInt::write(height, w)
       }
 
       Input::ToKey { amount, key_offsets, key_image } => {
         w.write_all(&[2])?;
-        write_varint(&amount.unwrap_or(0), w)?;
-        write_vec(write_varint, key_offsets, w)?;
+        VarInt::write(&amount.unwrap_or(0), w)?;
+        write_vec(VarInt::write, key_offsets, w)?;
         key_image.write(w)
       }
     }
@@ -87,9 +87,9 @@ impl Input {
   /// Read an Input.
   pub fn read<R: Read>(r: &mut R) -> io::Result<Input> {
     Ok(match read_byte(r)? {
-      255 => Input::Gen(read_varint(r)?),
+      255 => Input::Gen(VarInt::read(r)?),
       2 => {
-        let amount = read_varint(r)?;
+        let amount = VarInt::read(r)?;
         // https://github.com/monero-project/monero/
         //   blob/00fd416a99686f0956361d1cd0337fe56e58d4a7/
         //   src/cryptonote_basic/cryptonote_format_utils.cpp#L860-L863
@@ -99,7 +99,7 @@ impl Input {
         Input::ToKey {
           amount,
           // Each offset takes at least one byte, and this won't be in a miner transaction
-          key_offsets: read_vec(read_varint, Some(MAX_NON_MINER_TRANSACTION_SIZE), r)?,
+          key_offsets: read_vec(VarInt::read, Some(MAX_NON_MINER_TRANSACTION_SIZE), r)?,
           key_image: CompressedPoint::read(r)?,
         }
       }
@@ -122,7 +122,7 @@ pub struct Output {
 impl Output {
   /// Write the Output.
   pub fn write<W: Write>(&self, w: &mut W) -> io::Result<()> {
-    write_varint(&self.amount.unwrap_or(0), w)?;
+    VarInt::write(&self.amount.unwrap_or(0), w)?;
     w.write_all(&[2 + u8::from(self.view_tag.is_some())])?;
     w.write_all(&self.key.to_bytes())?;
     if let Some(view_tag) = self.view_tag {
@@ -140,7 +140,7 @@ impl Output {
 
   /// Read an Output.
   pub fn read<R: Read>(rct: bool, r: &mut R) -> io::Result<Output> {
-    let amount = read_varint(r)?;
+    let amount = VarInt::read(r)?;
     let amount = if rct {
       if amount != 0 {
         Err(io::Error::other("RCT TX output wasn't 0"))?;
@@ -182,9 +182,9 @@ impl Timelock {
   /// Write the Timelock.
   pub fn write<W: Write>(&self, w: &mut W) -> io::Result<()> {
     match self {
-      Timelock::None => write_varint(&0u8, w),
-      Timelock::Block(block) => write_varint(block, w),
-      Timelock::Time(time) => write_varint(time, w),
+      Timelock::None => VarInt::write(&0u8, w),
+      Timelock::Block(block) => VarInt::write(block, w),
+      Timelock::Time(time) => VarInt::write(time, w),
     }
   }
 
@@ -199,7 +199,7 @@ impl Timelock {
   pub fn read<R: Read>(r: &mut R) -> io::Result<Self> {
     const TIMELOCK_BLOCK_THRESHOLD: usize = 500_000_000;
 
-    let raw = read_varint::<_, u64>(r)?;
+    let raw = <u64 as VarInt>::read(r)?;
     Ok(if raw == 0 {
       Timelock::None
     } else if raw <
@@ -258,7 +258,7 @@ impl TransactionPrefix {
     self.additional_timelock.write(w)?;
     write_vec(Input::write, &self.inputs, w)?;
     write_vec(Output::write, &self.outputs, w)?;
-    write_varint(&self.extra.len(), w)?;
+    VarInt::write(&self.extra.len(), w)?;
     w.write_all(&self.extra)
   }
 
@@ -293,7 +293,7 @@ impl TransactionPrefix {
 
   fn hash(&self, version: u64) -> [u8; 32] {
     let mut buf = vec![];
-    write_varint(&version, &mut buf).expect("write failed but <Vec as io::Write> doesn't fail");
+    VarInt::write(&version, &mut buf).expect("write failed but <Vec as io::Write> doesn't fail");
     self.write(&mut buf).expect("write failed but <Vec as io::Write> doesn't fail");
     keccak256(buf)
   }
@@ -473,7 +473,7 @@ impl<P: PotentiallyPruned> Transaction<P> {
   /// Some writable transactions may not be readable if they're malformed, per Monero's consensus
   /// rules.
   pub fn write<W: Write>(&self, w: &mut W) -> io::Result<()> {
-    write_varint(&self.version(), w)?;
+    VarInt::write(&self.version(), w)?;
     match self {
       Transaction::V1 { prefix, signatures } => {
         prefix.write(w)?;
@@ -505,7 +505,7 @@ impl<P: PotentiallyPruned> Transaction<P> {
   /// deserializing. The result is not guaranteed to follow all Monero consensus rules or any
   /// specific set of consensus rules.
   pub fn read<R: Read>(r: &mut R) -> io::Result<Self> {
-    let version = read_varint(r)?;
+    let version = VarInt::read(r)?;
     let prefix = TransactionPrefix::read(r, version)?;
 
     if version == 1 {
@@ -541,7 +541,7 @@ impl<P: PotentiallyPruned> Transaction<P> {
         let mut buf = Vec::with_capacity(512);
 
         // We don't use `self.write` as that may write the signatures (if this isn't pruned)
-        write_varint(&self.version(), &mut buf)
+        VarInt::write(&self.version(), &mut buf)
           .expect("write failed but <Vec as io::Write> doesn't fail");
         prefix.write(&mut buf).expect("write failed but <Vec as io::Write> doesn't fail");
 

--- a/monero-oxide/wallet/address/src/lib.rs
+++ b/monero-oxide/wallet/address/src/lib.rs
@@ -385,7 +385,7 @@ impl<const ADDRESS_BYTES: u128> fmt::Display for Address<ADDRESS_BYTES> {
     if let AddressType::Featured { subaddress, payment_id, guaranteed } = self.kind {
       let features_uint =
         (u8::from(guaranteed) << 2) + (u8::from(payment_id.is_some()) << 1) + u8::from(subaddress);
-      write_varint(&features_uint, &mut data)
+      VarInt::write(&features_uint, &mut data)
         .expect("write failed but <Vec as io::Write> doesn't fail");
     }
     if let Some(id) = self.kind.payment_id() {
@@ -414,7 +414,7 @@ impl<const ADDRESS_BYTES: u128> Address<ADDRESS_BYTES> {
     let view = read_point(&mut raw).map_err(|_| AddressError::InvalidKey)?;
 
     if matches!(kind, AddressType::Featured { .. }) {
-      let features = read_varint::<_, u64>(&mut raw).map_err(|_| AddressError::InvalidLength)?;
+      let features = <u64 as VarInt>::read(&mut raw).map_err(|_| AddressError::InvalidLength)?;
       if (features >> 3) != 0 {
         Err(AddressError::UnknownFeatures(features))?;
       }

--- a/monero-oxide/wallet/src/extra.rs
+++ b/monero-oxide/wallet/src/extra.rs
@@ -137,7 +137,7 @@ impl ExtraField {
       }
       ExtraField::MergeMining(height, merkle) => {
         w.write_all(&[3])?;
-        write_varint(height, w)?;
+        VarInt::write(height, w)?;
         w.write_all(merkle)?;
       }
       ExtraField::PublicKeys(keys) => {
@@ -187,7 +187,7 @@ impl ExtraField {
       }),
       1 => ExtraField::PublicKey(read_point(r)?),
       2 => ExtraField::Nonce(read_vec(read_byte, Some(MAX_TX_EXTRA_NONCE_SIZE), r)?),
-      3 => ExtraField::MergeMining(read_varint(r)?, read_bytes(r)?),
+      3 => ExtraField::MergeMining(VarInt::read(r)?, read_bytes(r)?),
       4 => ExtraField::PublicKeys(read_vec(read_point, None, r)?),
       0xDE => ExtraField::MysteriousMinergate(read_vec(read_byte, None, r)?),
       _ => Err(io::Error::other("unknown extra field"))?,

--- a/monero-oxide/wallet/src/lib.rs
+++ b/monero-oxide/wallet/src/lib.rs
@@ -10,7 +10,7 @@ use zeroize::{Zeroize, Zeroizing};
 use curve25519_dalek::{Scalar, EdwardsPoint};
 
 use monero_oxide::{
-  io::write_varint,
+  io::VarInt,
   primitives::{Commitment, keccak256, keccak256_to_scalar},
   ringct::EncryptedAmount,
   transaction::Input,
@@ -61,7 +61,7 @@ impl SharedKeyDerivations {
         // If Gen, this should be the only input, making this loop somewhat pointless
         // This works and even if there were somehow multiple inputs, it'd be a false negative
         Input::Gen(height) => {
-          write_varint(height, &mut u).expect("write failed but <Vec as io::Write> doesn't fail");
+          VarInt::write(height, &mut u).expect("write failed but <Vec as io::Write> doesn't fail");
         }
         Input::ToKey { key_image, .. } => u.extend(key_image.to_bytes()),
       }
@@ -83,7 +83,7 @@ impl SharedKeyDerivations {
     // || o
     {
       let output_derivation: &mut Vec<u8> = output_derivation.as_mut();
-      write_varint(&o, output_derivation)
+      VarInt::write(&o, output_derivation)
         .expect("write failed but <Vec as io::Write> doesn't fail");
     }
 

--- a/monero-oxide/wallet/src/output.rs
+++ b/monero-oxide/wallet/src/output.rs
@@ -197,7 +197,7 @@ impl Metadata {
       w.write_all(&[0])?;
     }
 
-    write_varint(&self.arbitrary_data.len(), w)?;
+    VarInt::write(&self.arbitrary_data.len(), w)?;
     for part in &self.arbitrary_data {
       const _ASSERT_MAX_ARBITRARY_DATA_SIZE_FITS_WITHIN_U8: [();
         (u8::MAX as usize) - MAX_ARBITRARY_DATA_SIZE] = [(); _];
@@ -236,7 +236,7 @@ impl Metadata {
       arbitrary_data: {
         let mut data = vec![];
         let mut total_len = 0usize;
-        for _ in 0 .. read_varint::<_, usize>(r)? {
+        for _ in 0 .. <usize as VarInt>::read(r)? {
           let len = read_byte(r)?;
           let chunk = read_raw_vec(read_byte, usize::from(len), r)?;
           total_len = total_len.wrapping_add(chunk.len());

--- a/monero-oxide/wallet/src/send/mod.rs
+++ b/monero-oxide/wallet/src/send/mod.rs
@@ -489,7 +489,8 @@ impl SignableTransaction {
 
         https://gist.github.com/kayabaNerve/01c50bbc35441e0bbdcee63a9d823789
       */
-      const FEATURED_ADDRESS_DATA_SIZE_UPPER_BOUND: usize = 9 + 32 + 32 + 9 + 8;
+      const FEATURED_ADDRESS_DATA_SIZE_UPPER_BOUND: usize =
+        <u64 as VarInt>::UPPER_BOUND + 32 + 32 + <u64 as VarInt>::UPPER_BOUND + 8;
       // Checksum
       const FEATURED_ADDRESS_CHECKED_DATA_SIZE_UPPER_BOUND: usize =
         FEATURED_ADDRESS_DATA_SIZE_UPPER_BOUND + 4;

--- a/monero-oxide/wallet/src/send/tx.rs
+++ b/monero-oxide/wallet/src/send/tx.rs
@@ -6,7 +6,7 @@ use curve25519_dalek::{
 };
 
 use crate::{
-  io::{varint_len, write_varint, CompressedPoint},
+  io::{VarInt, CompressedPoint},
   primitives::Commitment,
   ringct::{
     clsag::Clsag, bulletproofs::Bulletproof, EncryptedAmount, RctType, RctBase, RctPrunable,
@@ -184,7 +184,7 @@ impl SignableTransaction {
             push_scalar(&mut bp);
           }
           for _ in 0 .. 2 {
-            write_varint(&lr_len, &mut bp)
+            VarInt::write(&lr_len, &mut bp)
               .expect("write failed but <Vec as io::Write> doesn't fail");
             for _ in 0 .. lr_len {
               push_point(&mut bp);
@@ -209,7 +209,7 @@ impl SignableTransaction {
             push_scalar(&mut bp);
           }
           for _ in 0 .. 2 {
-            write_varint(&lr_len, &mut bp)
+            VarInt::write(&lr_len, &mut bp)
               .expect("write failed but <Vec as io::Write> doesn't fail");
             for _ in 0 .. lr_len {
               push_point(&mut bp);
@@ -262,7 +262,7 @@ impl SignableTransaction {
       // weight
       // This should be because the lengths are equal, yet means if somehow none are equal, this
       // will still terminate successfully
-      if varint_len(possible_fee) <= fee_len {
+      if possible_fee.varint_len() <= fee_len {
         weight_and_fee = Some((base_weight + fee_len, possible_fee));
         break;
       }

--- a/monero-oxide/wallet/src/send/tx.rs
+++ b/monero-oxide/wallet/src/send/tx.rs
@@ -238,15 +238,17 @@ impl SignableTransaction {
     };
 
     // We now have the base weight, without the fee encoded
-    // The fee itself will impact the weight as its encoding is [1, 9] bytes long
-    let mut possible_weights = Vec::with_capacity(9);
-    for i in 1 ..= 9 {
+    // The fee itself will impact the weight as its encoding takes up a variable amount of bytes
+    let mut possible_weights = Vec::with_capacity(<u64 as VarInt>::UPPER_BOUND);
+    // Assert LOWER_BOUND == 1, which this code assumes
+    const _LOWER_BOUND_IS_LTE_ONE: [(); 1 - <u64 as VarInt>::LOWER_BOUND] = [(); _];
+    const _LOWER_BOUND_IS_GTE_ONE: [(); <u64 as VarInt>::LOWER_BOUND - 1] = [(); _];
+    for i in <u64 as VarInt>::LOWER_BOUND ..= <u64 as VarInt>::UPPER_BOUND {
       possible_weights.push(base_weight + i);
     }
-    debug_assert_eq!(possible_weights.len(), 9);
 
     // We now calculate the fee which would be used for each weight
-    let mut possible_fees = Vec::with_capacity(9);
+    let mut possible_fees = Vec::with_capacity(<u64 as VarInt>::UPPER_BOUND);
     for weight in possible_weights {
       possible_fees.push(self.fee_rate.calculate_fee_from_weight(weight));
     }
@@ -254,9 +256,8 @@ impl SignableTransaction {
     // We now look for the fee whose length matches the length used to derive it
     let mut weight_and_fee = None;
     for (fee_len, possible_fee) in possible_fees.into_iter().enumerate() {
+      // Increment by one as the enumeration is zero-indexed
       let fee_len = 1 + fee_len;
-      debug_assert!(1 <= fee_len);
-      debug_assert!(fee_len <= 9);
 
       // We use the first fee whose encoded length is not larger than the length used within this
       // weight

--- a/monero-oxide/wallet/src/tests/extra.rs
+++ b/monero-oxide/wallet/src/tests/extra.rs
@@ -1,7 +1,7 @@
 use curve25519_dalek::edwards::EdwardsPoint;
 
 use crate::{
-  io::{CompressedPoint, write_varint},
+  io::{VarInt, CompressedPoint},
   extra::{
     ARBITRARY_DATA_MARKER, MAX_TX_EXTRA_PADDING_COUNT, MAX_EXTRA_SIZE_BY_RELAY_RULE, ExtraField,
     Extra,
@@ -177,7 +177,7 @@ fn extra_mysterious_minergate_only() {
 #[test]
 fn extra_mysterious_minergate_only_large() {
   let mut buf: Vec<u8> = vec![222];
-  write_varint(&512u64, &mut buf).unwrap();
+  VarInt::write(&512u64, &mut buf).unwrap();
   buf.extend_from_slice(&vec![0; 512]);
   let extra = Extra::read(&mut buf.as_slice()).unwrap();
   assert_eq!(extra.0, vec![ExtraField::MysteriousMinergate(vec![0; 512])]);


### PR DESCRIPTION
Ensure it has documentation generated by unsealing it, yet requiring implementors implement a distinct `Sealed` trait (ensuring users cannot implement it themselves).

Moves `VarInt::into_u64` into `Sealed` so it's no longer part of our API commitment.

Removes `VarInt::BITS`, which was a requirement for our `read_varint` function. We now directly use `core::mem::size_of`, which is fine as this is only implemented for primitives.

Moves `read_varint`, `write_varint` into the trait.

Introduces `LOWER_BOUND`, `UPPER_BOUND` constants as suggested by @jeffro256. These do not use the `struct`s proposed in
https://github.com/monero-oxide/monero-oxide/pull/97 as it's unnecessary. Those `struct`s exist to provide a lengthy disclaimer these values aren't subject to. They are minimal/maximal bounds, are fundamental to their types, and we should have no problem committing to them within our API.

Adds links to Monero's implementation as reference.