### PR TITLE
Use `macos-15-intel` instead of `macos-13` due to `macos-13`'s scheduled removal

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
   clippy:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-15-intel, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
Also updates from `macos-14` to `macos-latest` to be consistent with `ubuntu-latest`, `windows-latest`.