### PR TITLE
Fix Rust docs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,6 +73,24 @@ jobs:
       - name: Run rustfmt
         run: cargo +${{ steps.nightly.outputs.version }} fmt -- --check
 
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+
+      - name: Get nightly version to use
+        id: nightly
+        shell: bash
+        run: echo "version=$(cat .github/nightly-version)" >> $GITHUB_OUTPUT
+
+      - name: Build Dependencies
+        uses: ./.github/actions/build-dependencies
+
+      - name: Buld Rust docs
+        run: |
+          rustup toolchain install ${{ steps.nightly.outputs.version }} --profile minimal -c rust-docs
+          RUSTDOCFLAGS="--cfg docsrs" cargo +${{ steps.nightly.outputs.version }} doc --no-deps --workspace --all-features
+
   machete:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Buld Rust docs
         run: |
           rustup toolchain install ${{ steps.nightly.outputs.version }} --profile minimal -c rust-docs
-          RUSTDOCFLAGS="--cfg docsrs" cargo +${{ steps.nightly.outputs.version }} doc --workspace --all-features
+          RUSTDOCFLAGS="--cfg docsrs" cargo +${{ steps.nightly.outputs.version }} doc --no-deps --workspace --all-features
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/monero-oxide/generators/src/hash_to_point.rs
+++ b/monero-oxide/generators/src/hash_to_point.rs
@@ -15,14 +15,14 @@ use crate::keccak256;
 /// implementation runs in constant time.
 ///
 /// According to the original authors
-/// (https://web.archive.org/web/20201028121818/https://cryptonote.org/whitepaper.pdf), this would
-/// implement https://arxiv.org/abs/0706.1448. Shen Noether also describes the algorithm
-/// (https://web.getmonero.org/resources/research-lab/pubs/ge_fromfe.pdf), yet without reviewing
+/// (<https://web.archive.org/web/20201028121818/https://cryptonote.org/whitepaper.pdf>), this
+/// would implement <https://arxiv.org/abs/0706.1448>. Shen Noether also describes the algorithm
+/// (<https://web.getmonero.org/resources/research-lab/pubs/ge_fromfe.pdf>), yet without reviewing
 /// its security and in a very straight-forward fashion.
 ///
 /// In reality, this implements Elligator 2 as detailed in
 /// "Elligator: Elliptic-curve points indistinguishable from uniform random strings"
-/// (https://eprint.iacr.org/2013/325). Specifically, Section 5.5 details the application of
+/// (<https://eprint.iacr.org/2013/325>). Specifically, Section 5.5 details the application of
 /// Elligator 2 to Curve25519, after which the result is mapped to Ed25519.
 ///
 /// As this only applies Elligator 2 once, it's limited to a subset of points where a certain

--- a/monero-oxide/src/merkle.rs
+++ b/monero-oxide/src/merkle.rs
@@ -20,7 +20,7 @@ use crate::primitives::keccak256;
 /// computation of the leaves. The value of this scratch space is undefined after the operation
 /// completes.
 ///
-/// This function returns [`None`] if the tree is empty and [`Some`](_) otherwise.
+/// This function returns [`None`] if the tree is empty and [`Some`] otherwise.
 pub fn merkle_root(mut leaves: impl AsMut<[[u8; 32]]>) -> Option<[u8; 32]> {
   let mut leaves = leaves.as_mut();
 

--- a/tests/verify-chain/src/main.rs
+++ b/tests/verify-chain/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 


### PR DESCRIPTION
1) A `doc_auto_cfg` remains in `tests/`
2) Dependencies used `doc_auto_cfg`, causing failures with the latest nightly

This also adds a check the docs build to the CI to prevent this from happening again, and corrects a few hyperlinks we could fix.