### PR TITLE
Add `SignableTransaction::unsigned_transaction`

### DIFF
--- a/monero-oxide/wallet/src/send/mod.rs
+++ b/monero-oxide/wallet/src/send/mod.rs
@@ -551,6 +551,16 @@ impl SignableTransaction {
     SignableTransactionWithKeyImages { intent: self, key_images }
   }
 
+  /// Fetch what the transaction will be, without its signatures (and associated fields).
+  ///
+  /// This returns `None` if an improper amount of key images is provided.
+  pub fn unsigned_transaction(self, key_images: Vec<CompressedPoint>) -> Option<Transaction> {
+    if self.inputs.len() != key_images.len() {
+      None?
+    };
+    Some(self.with_key_images(key_images).transaction_without_signatures())
+  }
+
   /// Sign this transaction.
   pub fn sign(
     self,


### PR DESCRIPTION
This appears to avoid internal invariants without issue, especially since the yielded transaction is from `monero-oxide` and can't hit invariants from there.

This intends to benefit delegated signing (hardware wallets), and also technically allows inspecting a `SignableTransaction` (without deferring to inspecting the serialization). It relates to (despite not properly resolving) https://github.com/monero-oxide/monero-oxide/issues/112 accordingly, yet that will need more effort to close.