### PR TITLE
Add convenience function `.with_payment_id` to monero-address

### DIFF
--- a/monero-oxide/wallet/address/src/lib.rs
+++ b/monero-oxide/wallet/address/src/lib.rs
@@ -484,7 +484,7 @@ impl<const ADDRESS_BYTES: u128> Address<ADDRESS_BYTES> {
   ///
   /// If the address does not support payment IDs within its format (e.g. subaddresses), then this
   /// function will return an error.
-  pub fn to_integrated(&self, payment_id: [u8; 8]) -> Result<Self, AddressError> {
+  pub fn with_payment_id(&self, payment_id: [u8; 8]) -> Result<Self, AddressError> {
     match self.kind {
       AddressType::Subaddress => Err(AddressError::UnsupportedPaymentID),
       AddressType::Featured { subaddress, guaranteed, .. } => Ok(Self::new(

--- a/monero-oxide/wallet/address/src/tests.rs
+++ b/monero-oxide/wallet/address/src/tests.rs
@@ -63,7 +63,7 @@ fn convert_to_integrated_address() {
   assert_eq!(addr.view.compress().to_bytes(), VIEW);
   assert_eq!(addr.to_string(), STANDARD);
 
-  let integrated_addr = addr.to_integrated(PAYMENT_ID).unwrap();
+  let integrated_addr = addr.with_payment_id(PAYMENT_ID).unwrap();
   assert_eq!(integrated_addr.to_string(), INTEGRATED);
   assert_eq!(integrated_addr.payment_id(), Some(PAYMENT_ID));
 }


### PR DESCRIPTION
This function makes it easier to make an integrated address out of an existing standard address (or even another integrated address, if you want to change the payment ID).
It's equivalent to the `make_integrated_address` RPC call from monero-wallet-rpc