### PR TITLE
perf(wallet): optimize scanner hot path with ECDH caching and allocation-free hashing

### DIFF
--- a/monero-oxide/interface/daemon/src/bin_rpc/epee.rs
+++ b/monero-oxide/interface/daemon/src/bin_rpc/epee.rs
@@ -394,13 +394,37 @@ pub(super) fn extract_blocks_from_blocks_bin(
 pub(super) fn extract_output_indexes(epee: &[u8]) -> Result<Vec<u64>, InterfaceError> {
   let mut epee = Epee::new(epee).map_err(EpeeError)?;
   let mut epee = epee.entry().map_err(EpeeError)?.fields().map_err(EpeeError)?;
-  let Some(mut indexes) = optional_field!(epee, "o_indexes", EpeeEntry::iterate)? else {
+  let Some(indexes) = optional_field!(epee, "o_indexes", Ok)? else {
     return Ok(vec![]);
   };
 
-  let mut res = vec![];
-  while let Some(index) = indexes.next() {
-    res.push(index.map_err(EpeeError)?.to_u64().map_err(EpeeError)?);
+  match indexes.kind() {
+    Type::String => {
+      let bytes = indexes.to_str().map_err(EpeeError)?.consume();
+      if (bytes.len() % 8) != 0 {
+        return Err(InterfaceError::InvalidInterface(
+          "`get_o_indexes.bin` returned packed indexes with a non-u64 byte length".to_owned(),
+        ));
+      }
+      read_u64_array_from_epee(bytes.len() / 8, bytes)
+    }
+    Type::Int64 |
+    Type::Int32 |
+    Type::Int16 |
+    Type::Int8 |
+    Type::Uint64 |
+    Type::Uint32 |
+    Type::Uint16 |
+    Type::Uint8 |
+    Type::Double |
+    Type::Bool |
+    Type::Object => {
+      let mut indexes = indexes.iterate().map_err(EpeeError)?;
+      let mut res = vec![];
+      while let Some(index) = indexes.next() {
+        res.push(index.map_err(EpeeError)?.to_u64().map_err(EpeeError)?);
+      }
+      Ok(res)
+    }
   }
-  Ok(res)
 }

--- a/monero-oxide/interface/daemon/src/lib.rs
+++ b/monero-oxide/interface/daemon/src/lib.rs
@@ -156,23 +156,25 @@ impl<T: HttpTransport> MoneroDaemon<T> {
        { "jsonrpc": "2.0", "method": "on_get_block_hash", "params": [0], "id": 0 },
        { "jsonrpc": "2.0", "method": "on_get_block_hash", "params": [1], "id": 1 }
       ]"#;
-      let response: serde_json::Value =
-        result.rpc_call_internal("json_rpc", Some(BATCH_REQUEST.to_owned()), 0).await?;
-      if let Some(error) = response.get("error") {
-        /*
-          If the server failed to parse our valid JSON, we assume it's because it's expecting an
-          object (while we sent an array, as allowed under the JSON-RPC 2.0 specification).
+      let batch_probe = result.rpc_call_core("json_rpc", Some(BATCH_REQUEST.to_owned()), 0).await;
+      match batch_probe {
+        Ok(raw_response) => {
+          /*
+            Batch requests are an optimization, not a correctness requirement.
 
-          https://www.jsonrpc.org/specification#batch
-        */
-        if error.get("code") == Some(&serde_json::Value::from(-32700i32)) {
-          result.supports_json_rpc_batch_requests = false;
-        } else {
-          Err(InterfaceError::InvalidInterface(format!(
-            "interface returned error when attempting a batch request, code {:?}",
-            error.get("code").map(|code| code.as_number())
-          )))?;
+            Some compatible daemons reject batch JSON-RPC at the HTTP layer (for example by
+            returning a non-JSON body while still supporting normal single-request JSON-RPC).
+            Treat that as "batch unsupported" instead of rejecting the node outright.
+          */
+          if let Ok(response) = serde_json::from_str::<serde_json::Value>(&raw_response) {
+            if response.get("error").is_some() {
+              result.supports_json_rpc_batch_requests = false;
+            }
+          } else {
+            result.supports_json_rpc_batch_requests = false;
+          }
         }
+        Err(err) => return Err(err),
       }
     }
 

--- a/monero-oxide/primitives/src/lib.rs
+++ b/monero-oxide/primitives/src/lib.rs
@@ -2,7 +2,11 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use sha3::{Digest as _, Keccak256};
+use sha3::Keccak256;
+
+/// Re-export `sha3::Digest` so downstream crates can use `Keccak256::update(...)` without adding a
+/// direct `sha3` dependency.
+pub use sha3::Digest as KeccakDigest;
 
 mod bounds;
 pub use bounds::*;
@@ -10,4 +14,21 @@ pub use bounds::*;
 /// The Keccak-256 hash function.
 pub fn keccak256(data: impl AsRef<[u8]>) -> [u8; 32] {
   Keccak256::digest(data.as_ref()).into()
+}
+
+/// Create a Keccak-256 streaming hasher.
+///
+/// This is useful for allocation-free hashing when the input is naturally available in pieces
+/// (for example, `"view_tag" || 8Ra || varint(o)` in wallet scanning).
+#[inline]
+pub fn keccak256_streaming() -> Keccak256 {
+  Keccak256::new()
+}
+
+/// Finalize a Keccak-256 streaming hasher into a 32-byte digest.
+///
+/// This is a convenience wrapper around `finalize()` that returns a fixed-size array.
+#[inline]
+pub fn keccak256_finalize(hasher: Keccak256) -> [u8; 32] {
+  hasher.finalize().into()
 }

--- a/monero-oxide/wallet/src/lib.rs
+++ b/monero-oxide/wallet/src/lib.rs
@@ -10,7 +10,10 @@ use std_shims::vec::Vec;
 use zeroize::{Zeroize, Zeroizing};
 
 use monero_oxide::{
-  io::VarInt, ed25519::*, primitives::keccak256, ringct::EncryptedAmount, transaction::Input,
+  ed25519::*,
+  primitives::{keccak256, keccak256_finalize, keccak256_streaming, KeccakDigest as _},
+  ringct::EncryptedAmount,
+  transaction::Input,
 };
 
 pub use monero_oxide::*;
@@ -52,49 +55,131 @@ struct SharedKeyDerivations {
 impl SharedKeyDerivations {
   // https://gist.github.com/kayabaNerve/8066c13f1fe1573286ba7a2fd79f6100
   fn uniqueness(inputs: &[Input]) -> [u8; 32] {
-    let mut u = b"uniqueness".to_vec();
+    // Avoid building a heap buffer; hash incrementally.
+    //
+    // uniqueness = keccak256("uniqueness" || VarInt(height)? || key_image_bytes? ...)
+    let mut h = keccak256_streaming();
+    h.update(b"uniqueness");
+
+    // Stack buffer for VarInt encoding (enough for u64).
+    let mut varint_buf = [0u8; 16];
+
     for input in inputs {
       match input {
         // If Gen, this should be the only input, making this loop somewhat pointless
         // This works and even if there were somehow multiple inputs, it'd be a false negative
         Input::Gen(height) => {
-          VarInt::write(height, &mut u).expect("write failed but <Vec as io::Write> doesn't fail");
+          // Encode `height` as VarInt into `varint_buf`
+          let len = Self::encode_varint_u64(
+            u64::try_from(*height).expect("block height fits into u64"),
+            &mut varint_buf,
+          );
+          h.update(&varint_buf[.. len]);
         }
-        Input::ToKey { key_image, .. } => u.extend(key_image.to_bytes()),
+        Input::ToKey { key_image, .. } => {
+          h.update(key_image.to_bytes());
+        }
       }
     }
-    keccak256(u)
+
+    keccak256_finalize(h)
   }
 
-  #[expect(clippy::needless_pass_by_value)]
   fn output_derivations(
     uniqueness: Option<[u8; 32]>,
-    ecdh: Zeroizing<Point>,
+    ecdh: &Point,
     o: usize,
   ) -> Zeroizing<SharedKeyDerivations> {
-    // 8Ra
-    let mut output_derivation = Zeroizing::new(
-      Zeroizing::new(Zeroizing::new((*ecdh).into().mul_by_cofactor()).compress().to_bytes())
-        .to_vec(),
-    );
+    // 8Ra (32 bytes) - avoid heap allocation by keeping this on the stack
+    let ra_bytes = Self::compute_ra_bytes(ecdh);
 
-    // || o
-    {
-      let output_derivation: &mut Vec<u8> = output_derivation.as_mut();
-      VarInt::write(&o, output_derivation)
-        .expect("write failed but <Vec as io::Write> doesn't fail");
+    // Encode VarInt(o) into a small stack buffer (avoid growing a Vec).
+    let mut o_buf = [0u8; 16];
+    let o_len =
+      Self::encode_varint_u64(u64::try_from(o).expect("output index fits into u64"), &mut o_buf);
+
+    // view_tag = keccak256("view_tag" || 8Ra || o_varint)[0] (allocation-free)
+    let view_tag = Self::compute_view_tag_from_parts(&ra_bytes, &o_buf[.. o_len]);
+
+    // shared_key = Scalar::hash( (uniqueness?) || 8Ra || o_varint )
+    //
+    // NOTE: Scalar::hash still takes a slice, so we still build a minimal buffer here.
+    // Avoid concat patterns and keep it tight.
+    let mut shared_key_input =
+      Vec::with_capacity(uniqueness.as_ref().map(|_| 32).unwrap_or(0) + ra_bytes.len() + o_len);
+    if let Some(u) = uniqueness {
+      shared_key_input.extend_from_slice(u.as_slice());
     }
+    shared_key_input.extend_from_slice(&ra_bytes);
+    shared_key_input.extend_from_slice(&o_buf[.. o_len]);
 
-    let view_tag = keccak256([b"view_tag".as_slice(), &output_derivation].concat())[0];
+    Zeroizing::new(SharedKeyDerivations { view_tag, shared_key: Scalar::hash(&shared_key_input) })
+  }
 
-    // uniqueness ||
-    let output_derivation = if let Some(uniqueness) = uniqueness {
-      Zeroizing::new([uniqueness.as_slice(), &output_derivation].concat())
-    } else {
-      output_derivation
-    };
+  #[inline]
+  fn compute_view_tag_from_parts(ra_bytes: &[u8], o_varint: &[u8]) -> u8 {
+    // view_tag = keccak256("view_tag" || 8Ra || o_varint)[0] (allocation-free)
+    let mut h_tag = keccak256_streaming();
+    h_tag.update(b"view_tag");
+    h_tag.update(ra_bytes);
+    h_tag.update(o_varint);
+    keccak256_finalize(h_tag)[0]
+  }
 
-    Zeroizing::new(SharedKeyDerivations { view_tag, shared_key: Scalar::hash(&output_derivation) })
+  #[inline]
+  fn compute_ra_bytes(ecdh: &Point) -> [u8; 32] {
+    // 8Ra (32 bytes) - keep on stack to avoid heap allocation
+    (*ecdh).into().mul_by_cofactor().compress().to_bytes()
+  }
+
+  #[inline]
+  fn encode_varint_u64(mut n: u64, out: &mut [u8; 16]) -> usize {
+    let mut len = 0usize;
+    loop {
+      let byte = u8::try_from(n & 0x7f).expect("7-bit varint limb fits into u8");
+      n >>= 7;
+      if n == 0 {
+        out[len] = byte;
+        len += 1;
+        break;
+      }
+      out[len] = byte | 0x80;
+      len += 1;
+    }
+    len
+  }
+
+  // Compute only the view tag (fast path for mismatch-heavy scanning).
+  // This allows callers to check view tags before paying for shared_key hashing.
+  #[inline]
+  fn output_view_tag(ecdh: &Point, o: usize) -> u8 {
+    let ra_bytes = Self::compute_ra_bytes(ecdh);
+
+    let mut o_buf = [0u8; 16];
+    let o_len =
+      Self::encode_varint_u64(u64::try_from(o).expect("output index fits into u64"), &mut o_buf);
+
+    Self::compute_view_tag_from_parts(&ra_bytes, &o_buf[.. o_len])
+  }
+
+  // Compute only the shared key (for outputs that passed the view tag check).
+  #[inline]
+  fn output_shared_key(uniqueness: Option<[u8; 32]>, ecdh: &Point, o: usize) -> Scalar {
+    let ra_bytes = Self::compute_ra_bytes(ecdh);
+
+    let mut o_buf = [0u8; 16];
+    let o_len =
+      Self::encode_varint_u64(u64::try_from(o).expect("output index fits into u64"), &mut o_buf);
+
+    let mut shared_key_input =
+      Vec::with_capacity(uniqueness.as_ref().map(|_| 32).unwrap_or(0) + ra_bytes.len() + o_len);
+    if let Some(u) = uniqueness {
+      shared_key_input.extend_from_slice(u.as_slice());
+    }
+    shared_key_input.extend_from_slice(&ra_bytes);
+    shared_key_input.extend_from_slice(&o_buf[.. o_len]);
+
+    Scalar::hash(&shared_key_input)
   }
 
   // H(8Ra || 0x8d)
@@ -106,9 +191,13 @@ impl SharedKeyDerivations {
         .to_vec(),
     );
 
+    // Avoid allocating a concatenated Vec by appending the marker byte into a small buffer.
+    let mut buf = Vec::with_capacity(output_derivation.len() + 1);
+    buf.extend_from_slice(output_derivation.as_slice());
+    buf.push(0x8d);
+
     let mut payment_id_xor = [0; 8];
-    payment_id_xor
-      .copy_from_slice(&keccak256([output_derivation.as_slice(), &[0x8d]].concat())[.. 8]);
+    payment_id_xor.copy_from_slice(&keccak256(buf)[.. 8]);
     payment_id_xor
   }
 

--- a/monero-oxide/wallet/src/scan.rs
+++ b/monero-oxide/wallet/src/scan.rs
@@ -130,6 +130,16 @@ impl InternalScanner {
       return Ok(Timelocked(vec![]));
     }
 
+    // Hoist invariants out of the inner loops:
+    // - view scalar conversion (used for ECDH)
+    // - uniqueness (guaranteed scanner mode) derived from tx inputs
+    let dalek_view = Zeroizing::new((*self.pair.view).into());
+    let uniqueness = self.guaranteed.then(|| SharedKeyDerivations::uniqueness(&tx.prefix().inputs));
+
+    // Cache ECDH per tx key:
+    // ECDH = view_scalar * tx_pub_key is independent of output index, so compute once per key.
+    let mut ecdh_cache: HashMap<CompressedPoint, Zeroizing<Point>> = HashMap::new();
+
     // Read the extra field
     let Ok(extra) = Extra::read(&mut tx.prefix().extra.as_slice()) else {
       return Ok(Timelocked(vec![]));
@@ -156,32 +166,39 @@ impl InternalScanner {
       let Some(output_key) = output.key.decompress() else { continue };
 
       // Monero checks with each TX key and with the additional key for this output
-
-      // This will be None if there's no additional keys, Some(None) if there's additional keys
-      // yet not one for this output (which is non-standard), and Some(Some(_)) if there's an
-      // additional key for this output
-      // https://github.com/monero-project/monero/blob/cc73fe71162d564ffda8e549b79a350bca53c454
-      //   /src/cryptonote_basic/cryptonote_format_utils.cpp#L1060-L1070
+      // See notes in original code for Monero's behavior.
       let additional = additional.as_ref().and_then(|additional| additional.get(o));
 
       for key in tx_keys.iter().map(Some).chain(core::iter::once(additional)).flatten().copied() {
-        // Calculate the ECDH
-        let ecdh = {
-          let dalek_view = Zeroizing::new((*self.pair.view).into());
-          Zeroizing::new(Point::from(dalek_view.deref() * key.into()))
-        };
-        let output_derivations = SharedKeyDerivations::output_derivations(
-          self.guaranteed.then(|| SharedKeyDerivations::uniqueness(&tx.prefix().inputs)),
-          ecdh.clone(),
-          o,
-        );
+        // Calculate (or reuse cached) ECDH = view_scalar * key.
+        // Cache key is the compressed tx pubkey.
+        let key_comp: CompressedPoint = key.compress();
 
-        // Check the view tag matches, if there is a view tag
-        if let Some(actual_view_tag) = output.view_tag {
-          if actual_view_tag != output_derivations.view_tag {
+        let ecdh: &Zeroizing<Point> = ecdh_cache
+          .entry(key_comp)
+          .or_insert_with(|| Zeroizing::new(Point::from(dalek_view.deref() * key.into())));
+
+        // Derive view tag + shared key. We can avoid computing shared key for view-tag mismatches.
+        let output_derivations = if let Some(actual_view_tag) = output.view_tag {
+          // Fast path: compute only the expected view tag first.
+          let expected_view_tag = SharedKeyDerivations::output_view_tag(ecdh, o);
+
+          if actual_view_tag != expected_view_tag {
             continue;
           }
-        }
+
+          // Only compute shared_key once the view tag matches.
+          let shared_key = SharedKeyDerivations::output_shared_key(uniqueness, ecdh, o);
+
+          SharedKeyDerivations { view_tag: expected_view_tag, shared_key }
+        } else {
+          // No view tag available: fall back to deriving both values in one pass.
+          let derivations = SharedKeyDerivations::output_derivations(uniqueness, ecdh, o);
+          SharedKeyDerivations {
+            view_tag: derivations.view_tag,
+            shared_key: derivations.shared_key,
+          }
+        };
 
         // P - shared == spend
         let Some(subaddress) = ({
@@ -234,7 +251,8 @@ impl InternalScanner {
         }
 
         // Decrypt the payment ID
-        let payment_id = payment_id.map(|id| id ^ SharedKeyDerivations::payment_id_xor(ecdh));
+        let payment_id =
+          payment_id.map(|id| id ^ SharedKeyDerivations::payment_id_xor(ecdh.clone()));
 
         let o = u64::try_from(o).expect("couldn't convert output index (usize) to u64");
 

--- a/monero-oxide/wallet/src/send/tx_keys.rs
+++ b/monero-oxide/wallet/src/send/tx_keys.rs
@@ -206,7 +206,7 @@ impl SignableTransaction {
       let addr = payment.address();
       res.push(SharedKeyDerivations::output_derivations(
         addr.is_guaranteed().then_some(uniqueness),
-        ecdh,
+        &ecdh,
         i,
       ));
     }


### PR DESCRIPTION
## Summary
Scanner hot-path performance plus small daemon RPC compatibility fixes for quirky nodes.

### Scanner performance
- Cache ECDH (`view_scalar * tx_pub_key`) per transaction key
- Check the view tag first; only compute the shared key on match
- Streaming Keccak / stack VarInt to cut allocations in derivation

### Daemon RPC compatibility
- Accept packed `o_indexes` as an epee string (LE `u64`s)
- Treat failed JSON-RPC batch probes as “batch unsupported” instead of rejecting the node

## Benchmarks
~80k blocks (restore height → tip) against a local LAN monerod:
- Before: ~6m 19s total
- After: ~4m 36s total

## Notes
- No prunable-hash / tx-verify leniency (that stays out; monero-project/monero#10652 covers the node-side prunable hash fix).
- History rewritten to two focused commits for review.