### PR TITLE
legacy multisig: fix definition of R_L in prover

### DIFF
--- a/monero-oxide/ringct/fcmp++/src/sal/legacy_multisig.rs
+++ b/monero-oxide/ringct/fcmp++/src/sal/legacy_multisig.rs
@@ -262,7 +262,7 @@ impl<R: Send + Sync + Clone + RngCore + CryptoRng, T: Sync + Clone + Debug + Tra
 
     let R_O = alpha_G + (T_ * *r_y);
     let R_P = R_z + (T_ * *r_r_p);
-    let R_L = nonce_sums[0][2] - R_z;
+    let R_L = nonce_sums[0][2] - (U * *r_z);
 
     let e = SpendAuthAndLinkability::challenge(
       self.signable_tx_hash,


### PR DESCRIPTION
```
nonce_sums[0][2] = alpha Hp(Ko)
R_L = r_x I_tilde - r_z U
    = r_x (I + r_i U) - (r_z_base + r_i alpha) U
    = alpha I + r_i alpha U - r_i alpha U - r_z_base u
    = alpha I - r_z_base u
```
In the code, `r_z = r_z_base` (notational ambiguity).