### PR TITLE
Use `saturating_sub` when checking remaining decoy candidates

### DIFF
--- a/monero-oxide/wallet/src/decoys.rs
+++ b/monero-oxide/wallet/src/decoys.rs
@@ -102,10 +102,10 @@ async fn select_n(
           #[cfg(test)]
           let max_iters = 1000 * usize::from(ring_len);
           max_iters
-        }) || ((highest_output_exclusive_bound -
-          u64::try_from(do_not_select.len()).expect("amount of ignored decoys exceeds 2^{64}")) <
-          u64::try_from(remaining - candidates.len())
-            .expect("amount of remaining selections exceeds 2^{64}"))
+        }) || (highest_output_exclusive_bound.saturating_sub(
+          u64::try_from(do_not_select.len()).expect("amount of ignored decoys exceeds 2^{64}"),
+        ) < u64::try_from(remaining - candidates.len())
+          .expect("amount of remaining selections exceeds 2^{64}"))
         {
           Err(InterfaceError::InternalError("hit decoy selection round limit".to_owned()))?;
         }


### PR DESCRIPTION
While reading `select_n` in `monero-wallet/src/decoys.rs`, the loop guard at lines 105-108 subtracts `do_not_select.len()` from `highest_output_exclusive_bound` with a bare `-`:

```rust
(highest_output_exclusive_bound -
  u64::try_from(do_not_select.len()).expect(...)) <
  u64::try_from(remaining - candidates.len()).expect(...)
```

`do_not_select` accumulates across the outer loop and is never reset, so its length is only bounded by the iteration cap (`max_iters`), not by `highest_output_exclusive_bound`. When it exceeds the bound the subtraction underflows: it traps under `overflow-checks`, and otherwise wraps to a large value which makes the `< remaining` comparison always false. The loop still terminates through the adjacent iteration-cap check, but this branch stops contributing the bound it is meant to.

This switches it to `saturating_sub`, so the guard reads `0 < remaining` in that case and short-circuits as intended. It mirrors the `saturating_sub` already used a few lines above for the analogous `highest_output_exclusive_bound` check, and the `checked_sub` used for the distribution lookup just below.

No behavior change for the normal path; this only hardens the edge case. `+1.96 build`, `+nightly clippy`, and the `monero-wallet` test suite pass locally.