### PR TITLE
ci: trust Homebrew RISC-V formula for no-std macOS jobs

### DIFF
--- a/.github/workflows/no-std.yml
+++ b/.github/workflows/no-std.yml
@@ -8,11 +8,15 @@ on:
     paths:
       - "monero-oxide/**"
       - "tests/no-std/**"
+      - ".github/workflows/no-std.yml"
+      - ".github/actions/build-dependencies/**"
 
   pull_request:
     paths:
       - "monero-oxide/**"
       - "tests/no-std/**"
+      - ".github/workflows/no-std.yml"
+      - ".github/actions/build-dependencies/**"
 
   workflow_dispatch:
 
@@ -20,6 +24,7 @@ jobs:
   build:
     name: Confirm all no-`std` crates build for no-`std` targets
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-26-intel, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -46,7 +51,10 @@ jobs:
           if [ "$RUNNER_OS" = "Linux" ]; then
             sudo apt install -y gcc-riscv64-unknown-elf gcc-multilib
           elif [ "$RUNNER_OS" = "macOS" ]; then
+            # Homebrew 6.0 requires explicit trust for third-party taps before
+            # formulae from them can be evaluated/installed.
             brew tap riscv-software-src/riscv
+            brew trust --formula riscv-software-src/riscv/riscv-tools
             brew install riscv-tools
           elif [ "$RUNNER_OS" = "Windows" ]; then
             /C/msys64/usr/bin/pacman.exe -Syu --noconfirm


### PR DESCRIPTION
## Summary
- Fix no-std CI on macOS after Homebrew 6.0 tap-trust enforcement (`Refusing to load formula ... from untrusted tap`)
- Trust only `riscv-software-src/riscv/riscv-tools` before install
- Run the workflow when `.github/workflows/no-std.yml` changes, and set `fail-fast: false` so one OS does not cancel the rest

## Context
This has been failing across PRs (including #166) on `macos-26-intel` / `macos-latest` during “Install RISC-V Toolchain”. Linux/Windows were cancelled by matrix fail-fast rather than showing real results.

Refs: https://docs.brew.sh/Tap-Trust · Homebrew 6.0.0 release notes

## Test plan
- [ ] no-std workflow runs on this PR (path filter includes the workflow file)
- [ ] macOS jobs get past `brew install riscv-tools`
- [ ] Ubuntu / Windows no-std jobs complete instead of being cancelled by fail-fast

Made with [Cursor](https://cursor.com)