### PR TITLE
Ready crates for publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "monero-daemon-rpc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "hex",
  "monero-address",
@@ -856,11 +856,11 @@ dependencies = [
 
 [[package]]
 name = "monero-epee"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "monero-interface"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "hex",
  "monero-oxide",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "monero-oxide"
-version = "0.1.4-alpha"
+version = "0.1.0"
 dependencies = [
  "curve25519-dalek",
  "hex",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "monero-wallet"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "curve25519-dalek",
  "flexible-transcript",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "monero-epee"
-version = "0.3.0"
+version = "0.2.1"
 
 [[package]]
 name = "monero-interface"

--- a/monero-oxide/Cargo.toml
+++ b/monero-oxide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monero-oxide"
-version = "0.1.4-alpha"
+version = "0.1.0"
 description = "A modern Monero transaction library"
 license = "MIT"
 repository = "https://github.com/monero-oxide/monero-oxide/tree/main/monero-oxide"

--- a/monero-oxide/epee/Cargo.toml
+++ b/monero-oxide/epee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monero-epee"
-version = "0.3.0"
+version = "0.2.1"
 description = "A library for working with `epee`-encoded data"
 license = "MIT"
 repository = "https://github.com/monero-oxide/monero-oxide/tree/main/monero-oxide/epee"

--- a/monero-oxide/epee/Cargo.toml
+++ b/monero-oxide/epee/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "monero-epee"
-version = "0.2.0"
+version = "0.3.0"
 description = "A library for working with `epee`-encoded data"
 license = "MIT"
+repository = "https://github.com/monero-oxide/monero-oxide/tree/main/monero-oxide/epee"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
 rust-version = "1.81"

--- a/monero-oxide/interface/Cargo.toml
+++ b/monero-oxide/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monero-interface"
-version = "0.1.0"
+version = "0.2.0"
 description = "Traits for interfacing with the Monero network, built around monero-oxide"
 license = "MIT"
 repository = "https://github.com/monero-oxide/monero-oxide/tree/main/monero-oxide/interface"
@@ -23,7 +23,7 @@ thiserror = { version = "2", default-features = false }
 zeroize = { version = "^1.5", default-features = false, features = ["zeroize_derive"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 
-monero-oxide = { path = "..", default-features = false }
+monero-oxide = { path = "..", version = "0.1", default-features = false }
 
 [features]
 std = [

--- a/monero-oxide/interface/daemon/Cargo.toml
+++ b/monero-oxide/interface/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monero-daemon-rpc"
-version = "0.1.0"
+version = "0.2.0"
 description = "An interface to a Monero daemon"
 license = "MIT"
 repository = "https://github.com/monero-oxide/monero-oxide/tree/main/monero-oxide/interface/daemon"
@@ -22,11 +22,11 @@ hex = { version = "0.4", default-features = false, features = ["alloc"] }
 serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 
-monero-oxide = { path = "../..", default-features = false }
-monero-address = { path = "../../wallet/address", default-features = false }
-monero-interface = { path = "..", default-features = false }
+monero-oxide = { path = "../..", version = "0.1", default-features = false }
+monero-address = { path = "../../wallet/address", version = "0.1", default-features = false }
+monero-interface = { path = "..", version = "0.2", default-features = false }
 
-monero-epee = { path = "../../epee", default-features = false }
+monero-epee = { path = "../../epee", version = "0.3", default-features = false }
 
 [features]
 std = [

--- a/monero-oxide/interface/daemon/Cargo.toml
+++ b/monero-oxide/interface/daemon/Cargo.toml
@@ -26,7 +26,7 @@ monero-oxide = { path = "../..", version = "0.1", default-features = false }
 monero-address = { path = "../../wallet/address", version = "0.1", default-features = false }
 monero-interface = { path = "..", version = "0.2", default-features = false }
 
-monero-epee = { path = "../../epee", version = "0.3", default-features = false }
+monero-epee = { path = "../../epee", version = "0.2", default-features = false }
 
 [features]
 std = [

--- a/monero-oxide/interface/daemon/simple-request/Cargo.toml
+++ b/monero-oxide/interface/daemon/simple-request/Cargo.toml
@@ -3,7 +3,7 @@ name = "monero-simple-request-rpc"
 version = "0.1.0"
 description = "RPC connection to a Monero daemon via simple-request, built around monero-oxide"
 license = "MIT"
-repository = "https://github.com/monero-oxide/monero-oxide/tree/main/monero-oxide/interface/simple-request"
+repository = "https://github.com/monero-oxide/monero-oxide/tree/main/monero-oxide/interface/daemon/simple-request"
 authors = ["Luke Parker <lukeparker5132@gmail.com>"]
 edition = "2021"
 rust-version = "1.89"
@@ -22,7 +22,7 @@ digest_auth = { version = "0.3", default-features = false }
 simple-request = { version = "0.2", default-features = false, features = ["tls"] }
 tokio = { version = "1", default-features = false }
 
-monero-daemon-rpc = { path = "..", default-features = false, features = ["std"] }
+monero-daemon-rpc = { path = "..", version = "0.2", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 monero-oxide = { path = "../../..", default-features = false, features = ["std"] }

--- a/monero-oxide/wallet/Cargo.toml
+++ b/monero-oxide/wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monero-wallet"
-version = "0.1.0"
+version = "0.2.0"
 description = "Wallet functionality for the Monero protocol, built around monero-oxide"
 license = "MIT"
 repository = "https://github.com/monero-oxide/monero-oxide/tree/main/monero-oxide/wallet"
@@ -41,10 +41,10 @@ frost = { package = "modular-frost", version = "0.11", default-features = false,
 
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 
-monero-clsag = { path = "../ringct/clsag", default-features = false }
-monero-oxide = { path = "..", default-features = false }
-monero-interface = { path = "../interface", default-features = false }
-monero-address = { path = "./address", default-features = false }
+monero-clsag = { path = "../ringct/clsag", version = "0.1", default-features = false }
+monero-oxide = { path = "..", version = "0.1", default-features = false }
+monero-interface = { path = "../interface", version = "0.2", default-features = false }
+monero-address = { path = "./address", version = "0.1", default-features = false }
 
 [dev-dependencies]
 serde = { version = "1", default-features = false, features = ["derive", "alloc", "std"] }

--- a/monero-oxide/wallet/address/Cargo.toml
+++ b/monero-oxide/wallet/address/Cargo.toml
@@ -20,10 +20,10 @@ thiserror = { version = "2", default-features = false }
 
 zeroize = { version = "^1.5", default-features = false, features = ["zeroize_derive"] }
 
-monero-io = { path = "../../io", default-features = false }
-monero-ed25519 = { path = "../../ed25519", default-features = false }
-monero-primitives = { path = "../../primitives", default-features = false }
-monero-base58 = { path = "../base58", default-features = false }
+monero-io = { path = "../../io", version = "0.1", default-features = false }
+monero-ed25519 = { path = "../../ed25519", version = "0.1", default-features = false }
+monero-primitives = { path = "../../primitives", version = "0.1", default-features = false }
+monero-base58 = { path = "../base58", version = "0.1", default-features = false }
 
 [dev-dependencies]
 rand_core = { version = "0.6", default-features = false, features = ["std"] }

--- a/monero-oxide/wallet/base58/Cargo.toml
+++ b/monero-oxide/wallet/base58/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 std-shims = { version = "0.1.5", default-features = false }
-monero-primitives = { path = "../../primitives", default-features = false }
+monero-primitives = { path = "../../primitives",version = "0.1", default-features = false }
 
 [dev-dependencies]
 rand_core = { version = "0.6", default-features = false, features = ["std"] }


### PR DESCRIPTION
Here is what I have done:

monero-io: kept 0.1.0, the published version is 0.0.1
monero-ed25519: kept 0.1.0, not published yet.
monero-epee: bumped to 0.3.0
monero-primitives: kept 0.1.0, the published version is 0.0.1

monero-borromean: kept 0.1.0, the published version is 0.0.1
monero-bulletproofs-generators: kept 0.1.0, not published yet.
monero-bulletproofs: kept 0.1.0, the published version is 0.0.1
monero-clsag: kept 0.1.0, the published version is 0.0.1
monero-mlsag: kept 0.1.0, the published version is 0.0.1

monero-interface: bumped to 0.2.0
monero-daemon-rpc: bumped to 0.2.0
monero-simple-request-rpc: kept 0.1.0, not published yet.

monero-oxide: Changed to 0.1.0, the published version is 0.0.1

monero-address: kept 0.1.0, the published version is 0.0.1
monero-base58: kept 0.1.0, the published version is 0.0.1
monero-wallet: Was part of the hijacked crates, bumped to 0.2.0 

--- 

Do we want to update our deps first? I think so, but I held off for now.