### PR TITLE
Remove Immunefi BBP from `Security.md`

### DIFF
--- a/Security.md
+++ b/Security.md
@@ -5,13 +5,8 @@
 Bugs in monero-oxide which cause a downstream project to be at risk of loss of
 funds, impact users' privacy, risk a Denial of Service, or are similarly
 problematic issues, should be reported via
-[monero-oxide's Bug Bounty Program](
-  https://immunefi.com/bug-bounty/monero-oxide/information/
-). This bug bounty was generously sponsored by
-[Power Up Privacy](https://powerupprivacy.com/) who directly handles payouts.
-Alternatively, for users without Immunefi accounts, security issues may be
-reported via [GitHub](https://github.com/monero-oxide/monero-oxide/security),
-or as a manner of _least preference_, a maintainer (as listed in our
+[GitHub](https://github.com/monero-oxide/monero-oxide/security), or
+unpreferably, a maintainer (as listed in our
 [Governance document](/Governance.md)) may be messaged over Matrix.
 
 Public disclosure, such as opening a GitHub issue, is not responsible and


### PR DESCRIPTION
This was the sole reference to it I found in our entire repository, suprisingly.

This reflects how the BBP has been _paused_ and is not currently able to be submitted to. We are unable to offer rewards for security issues at this time. We are discussing ways we can host a BBP moving forward, continuing our BBP with Immunefi, but will need to sort out a new way to handle payouts.

---

This was paused entirely of our own volition, and not due to any disagreement with Immunefi. I am incredibly proud `monero-oxide` never 'lost' a mediation (never was asked to issue a reward we initially declined to, never told a bug was of higher severity than we classified it, etc.) and had the best response time on the entire platform for almost the entire time we managed the BBP, including at the end. We tried to always treat whitehats fairly and promptly, and issued a fair amount of rewards on a good-will basis (e.g. not out of obligation). This was even as we had incredibly strenuous and exact standards, and ran this BBP by volunteering our time, never having 'triagers' or an external security service.

The BBP was made possible thanks to the financial sponsorship of Power Up Privacy, and later via generous donations of someone I'm happy to call a friend. However, the current sponsor is no longer feasibly able to continue these donations, hence the current actions. We have nothing but thanks for how they've enabled us to better secure monero-oxide and for how long we were able to do so.