### PR TITLE
Add docs.rs badge to monero-oxide readme

### DIFF
--- a/monero-oxide/README.md
+++ b/monero-oxide/README.md
@@ -1,6 +1,4 @@
-[![Documentation](https://docs.rs/monero-oxide/badge.svg)](https://docs.rs/monero-oxide)
-
-# monero-oxide
+# [monero-oxide](https://docs.rs/monero-oxide)
 
 A modern Monero transaction library. It provides a modern, Rust-friendly view of
 the Monero protocol.

--- a/monero-oxide/README.md
+++ b/monero-oxide/README.md
@@ -1,3 +1,5 @@
+[![Documentation](https://docs.rs/monero-oxide/badge.svg)](https://docs.rs/monero-oxide)
+
 # monero-oxide
 
 A modern Monero transaction library. It provides a modern, Rust-friendly view of


### PR DESCRIPTION
I think a link to the documentation could be useful. If you don't want a badge, I can change it to a textual link .

(Ideally, links should be added to all readme files here.)