### PR TITLE
Respond to #201

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,7 @@ version = "0.2.1"
 
 [[package]]
 name = "monero-interface"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "hex",
  "monero-oxide",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "monero-simple-request-rpc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "digest_auth",
  "hex",

--- a/monero-oxide/interface/Cargo.toml
+++ b/monero-oxide/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monero-interface"
-version = "0.2.0"
+version = "0.2.1"
 description = "Traits for interfacing with the Monero network, built around monero-oxide"
 license = "MIT"
 repository = "https://github.com/monero-oxide/monero-oxide/tree/main/monero-oxide/interface"

--- a/monero-oxide/interface/README.md
+++ b/monero-oxide/interface/README.md
@@ -24,6 +24,10 @@ with _when_ they make requests, as discussed in
   https://eprint.iacr.org/2020/220
 ).
 
+For a literal instantiation of these traits, please see
+[`monero-daemon-rpc`](https://docs.rs/monero-daemon-rpc) as one option premised
+on a remote Monero daemon.
+
 This library is usable under no-`std`, with `alloc`, when the `std` feature (on
 by default) is disabled.
 

--- a/monero-oxide/interface/daemon/simple-request/Cargo.toml
+++ b/monero-oxide/interface/daemon/simple-request/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monero-simple-request-rpc"
-version = "0.1.0"
+version = "0.1.1"
 description = "RPC connection to a Monero daemon via simple-request, built around monero-oxide"
 license = "MIT"
 repository = "https://github.com/monero-oxide/monero-oxide/tree/main/monero-oxide/interface/daemon/simple-request"

--- a/monero-oxide/interface/daemon/simple-request/src/lib.rs
+++ b/monero-oxide/interface/daemon/simple-request/src/lib.rs
@@ -169,8 +169,12 @@ impl SimpleRequestTransport {
     let _read_response_before_next_request = self.read_response_before_next_request.lock().await;
 
     let request_fn = |uri| {
-      Request::post(uri)
-        .header("Content-Type", "application/json")
+      let mut request = Request::post(uri);
+      #[expect(clippy::case_sensitive_file_extension_comparisons)]
+      if !route.ends_with(".bin") {
+        request = request.header("Content-Type", "application/json");
+      }
+      request
         .body(body.clone().into())
         .map_err(|e| InterfaceError::InterfaceError(format!("couldn't make request: {e:?}")))
     };

--- a/monero-oxide/interface/daemon/simple-request/src/lib.rs
+++ b/monero-oxide/interface/daemon/simple-request/src/lib.rs
@@ -170,6 +170,7 @@ impl SimpleRequestTransport {
 
     let request_fn = |uri| {
       Request::post(uri)
+        .header("Content-Type", "application/json")
         .body(body.clone().into())
         .map_err(|e| InterfaceError::InterfaceError(format!("couldn't make request: {e:?}")))
     };


### PR DESCRIPTION
I also took the liberty of correcting a gap in our documentation I noticed after we published releases. This does a version bump so once merged, these can also be released.

Note I don't think #201 is inherently valid and it should be read before this is merged to provide context, even though I support this change just to be polite.